### PR TITLE
Fix incorrect case/capitalization in reference documents (26/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -131,8 +131,8 @@ Get-History | Sort-Object -Property Id -Descending
    8 Get-Command Sort-Object -Syntax
    7 Get-Command Sort-Object -ShowCommandInfo
    6 Get-ChildItem -Path C:\Test | Sort-Object -Property Length
-   5 Get-Help Clear-History -online
-   4 Get-Help Clear-History -full
+   5 Get-Help Clear-History -Online
+   4 Get-Help Clear-History -Full
    3 Get-ChildItem | Get-Member
    2 Get-Command Sort-Object -Syntax
    1 Set-Location C:\Test\
@@ -478,8 +478,8 @@ use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
-- `expression` - `<string>` or `<script block>`
-- `ascending` or `descending` - `<boolean>`
+- `Expression` - `<string>` or `<script block>`
+- `Ascending` or `Descending` - `<boolean>`
 
 For more information, see
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md).

--- a/reference/5.1/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -67,7 +67,7 @@ This example gets a list of the processes running on the computer, saves them to
 variable, and pipes them to `Select-Object`.
 
 ```powershell
-Get-Process notepad | Tee-Object -Variable proc | Select-Object processname,handles
+Get-Process notepad | Tee-Object -Variable proc | Select-Object ProcessName, Handles
 ```
 
 ```Output
@@ -88,8 +88,8 @@ This example saves a list of system files in a two log files, a cumulative file 
 
 ```powershell
 Get-ChildItem -Path D: -File -System -Recurse |
-  Tee-Object -FilePath "c:\test\AllSystemFiles.txt" -Append |
-    Out-File c:\test\NewSystemFiles.txt
+  Tee-Object -FilePath "C:\test\AllSystemFiles.txt" -Append |
+    Out-File C:\test\NewSystemFiles.txt
 ```
 
 The command uses the `Get-ChildItem` cmdlet to do a recursive search for system files on the D:

--- a/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -44,7 +44,7 @@ This example starts a trace of metadata processing, parameter binding, and cmdle
 destruction of the `Get-Process Notepad` expression.
 
 ```powershell
-Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+Trace-Command -Name Metadata, ParameterBinding, Cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
 It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify

--- a/reference/5.1/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -85,12 +85,12 @@ Stream                   Length
 Zone.Identifier              26
 
 PS C:\> C:\ps-test\Start-ActivityTracker.ps1
-c:\ps-test\Start-ActivityTracker.ps1 : File c:\ps-test\Start-ActivityTracker.ps1 cannot
-be loaded. The file c:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
+C:\ps-test\Start-ActivityTracker.ps1 : File C:\ps-test\Start-ActivityTracker.ps1 cannot
+be loaded. The file C:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
 will not execute on the system. For more information, see about_Execution_Policies.
 
 At line:1 char:1
-+ c:\ps-test\Start-ActivityTracker.ps1
++ C:\ps-test\Start-ActivityTracker.ps1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : SecurityError: (:) [], PSSecurityException
     + FullyQualifiedErrorId : UnauthorizedAccess

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -51,11 +51,11 @@ This command reloads the formatting files that it loaded previously.
 ### Example 2: Reload formatting files and trace and log formatting files
 
 ```powershell
-Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
+Update-FormatData -AppendPath Trace.format.ps1xml, Log.format.ps1xml
 ```
 
 This command reloads the formatting files into the session, including two new files,
-Trace.format.ps1xml and Log.format.ps1xml.
+`Trace.format.ps1xml` and `Log.format.ps1xml`.
 
 Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
 after the formatting data from the built-in files.
@@ -66,7 +66,7 @@ are not referenced in the built-in files.
 ### Example 3: Edit a formatting file and reload it
 
 ```powershell
-Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+Update-FormatData -PrependPath "C:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
@@ -75,15 +75,15 @@ Update-FormatData
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+The first command adds the `NewFiles.format.ps1xml` file to the session. It uses the **PrependPath**
 parameter because the file contains formatting data for objects that are referenced in the built-in
 files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
-file.
+After adding the `NewFiles.format.ps1xml` file and testing it in these sessions, the author edits
+the file.
 
 The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
-NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+`NewFiles.format.ps1xml` file was previously loaded, `Update-FormatData` automatically reloads it
 without using parameters.
 
 ## PARAMETERS

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-List.md
@@ -51,43 +51,43 @@ interface.
 
 In this example we create a class that represents a deck of cards where the cards are stored as a
 **List** collection object. The **NewDeck()** method uses `Update-List`to add a complete deck of
-card values to the **cards** collection.
+card values to the **Cards** collection.
 
 ```powershell
 class Cards {
 
-    [System.Collections.Generic.List[string]]$cards
-    [string]$name
+    [System.Collections.Generic.List[string]]$Cards
+    [string]$Name
 
     Cards([string]$_name) {
-        $this.name = $_name
-        $this.cards = [System.Collections.Generic.List[string]]::new()
+        $this.Name = $_name
+        $this.Cards = [System.Collections.Generic.List[string]]::new()
     }
 
     NewDeck() {
         $_suits = [char]0x2663,[char]0x2666,[char]0x2665,[char]0x2660
         $_values = 'A',2,3,4,5,6,7,8,9,10,'J','Q','K'
         $_deck = foreach ($s in $_suits){ foreach ($v in $_values){ "$v$s"} }
-        $this | Update-List -Property cards -Add $_deck | Out-Null
+        $this | Update-List -Property Cards -Add $_deck | Out-Null
     }
 
     Show() {
         Write-Host
-        Write-Host $this.name ": " $this.cards[0..12]
-        if ($this.cards.count -gt 13) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[13..25]
+        Write-Host $this.Name ": " $this.Cards[0..12]
+        if ($this.Cards.Count -gt 13) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[13..25]
         }
-        if ($this.cards.count -gt 26) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[26..38]
+        if ($this.Cards.Count -gt 26) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[26..38]
         }
-        if ($this.cards.count -gt 39) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[39..51]
+        if ($this.Cards.Count -gt 39) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[39..51]
         }
     }
 
-    Shuffle() { $this.cards = Get-Random -InputObject $this.cards -Count 52 }
+    Shuffle() { $this.Cards = Get-Random -InputObject $this.Cards -Count 52 }
 
-    Sort() { $this.cards.Sort() }
+    Sort() { $this.Cards.Sort() }
 }
 ```
 
@@ -111,10 +111,10 @@ $deck.Shuffle()
 $deck.Show()
 
 # Deal two hands
-$player1 | Update-List -Property cards -Add $deck.cards[0,2,4,6,8] | Out-Null
-$player2 | Update-List -Property cards -Add $deck.cards[1,3,5,7,9] | Out-Null
-$deck | Update-List -Property cards -Remove $player1.cards | Out-Null
-$deck | Update-List -Property cards -Remove $player2.cards | Out-Null
+$player1 | Update-List -Property Cards -Add $deck.Cards[0,2,4,6,8] | Out-Null
+$player2 | Update-List -Property Cards -Add $deck.Cards[1,3,5,7,9] | Out-Null
+$deck | Update-List -Property Cards -Remove $player1.Cards | Out-Null
+$deck | Update-List -Property Cards -Remove $player2.Cards | Out-Null
 
 $player1.Show()
 $player2.Show()
@@ -150,11 +150,11 @@ example, Player 1 wants to discard the `4♦` and `6♦` and get two new cards.
 
 ```powershell
 # Player 1 wants two new cards - remove 2 cards & add 2 cards
-$player1 | Update-List -Property cards -Remove $player1.cards[0,4] -Add $deck.cards[0..1] | Out-Null
+$player1 | Update-List -Property Cards -Remove $player1.Cards[0,4] -Add $deck.Cards[0..1] | Out-Null
 $player1.Show()
 
 # remove dealt cards from deck
-$deck | Update-List -Property cards -Remove $deck.cards[0..1] | Out-Null
+$deck | Update-List -Property Cards -Remove $deck.Cards[0..1] | Out-Null
 $deck.Show()
 ```
 
@@ -187,7 +187,7 @@ Remove                         {43}
 ```
 
 ```powershell
-([PSListModifier]($changeInstructions)).ApplyTo($list)
+([pslistmodifier]($changeInstructions)).ApplyTo($list)
 $list
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -153,7 +153,7 @@ when no properties are specified. Because the type data is not specified in a `T
 it is effective only in the current session.
 
 ```powershell
-Get-Date | Format-list
+Get-Date | Format-List
 
 Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet @(
     'DateTime'

--- a/reference/5.1/Microsoft.PowerShell.Utility/Wait-Debugger.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Wait-Debugger.md
@@ -49,7 +49,7 @@ function Test-Condition {
         [string]$Message = "Hello, $Name!"
     )
 
-    if ($Name -eq $env:USERNAME) {
+    if ($Name -eq $Env:USERNAME) {
         Write-Output "$Message"
     } else {
         # Remove after debugging
@@ -70,7 +70,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
 [DBG]: PS D:\>> l
 
     8:
-    9:      if ($Name -eq $env:USERNAME) {
+    9:      if ($Name -eq $Env:USERNAME) {
    10:          Write-Output "$Message"
    11:      } else {
    12:          # Remove after debugging
@@ -80,7 +80,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
    16:      }
    17:  }
 
-[DBG]: PS D:\>> $env:USERNAME
+[DBG]: PS D:\>> $Env:USERNAME
 User01
 [DBG]: PS D:\>> exit
 PS D:\>
@@ -113,7 +113,7 @@ class FileResource
 
     [void] Set() {
         $fileExists = $this.TestFilePath($this.Path)
-        if ($this.ensure -eq [Ensure]::Present) {
+        if ($this.Ensure -eq [Ensure]::Present) {
             if (! $fileExists) {
                $this.CopyFile()
             }

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
@@ -53,7 +53,7 @@ Non-terminating errors write an error to the error stream, but they don't stop c
 If a non-terminating error is declared on one item in a collection of input items, the command
 continues to process the other items in the collection.
 
-To declare a terminating error, use the `Throw` keyword.
+To declare a terminating error, use the `throw` keyword.
 For more information, see [about_Throw](../Microsoft.PowerShell.Core/About/about_Throw.md).
 
 ## EXAMPLES

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -29,7 +29,7 @@ text that appears above and below the progress bar.
 
 ## EXAMPLES
 
-### Example 1: Display the progress of a For loop
+### Example 1: Display the progress of a `for` loop
 
 ```powershell
 for ($i = 1; $i -le 100; $i++ ) {
@@ -44,7 +44,7 @@ The `Write-Progress` cmdlet includes a status bar heading `Activity`, a status l
 variable `$i` (the counter in the `for` loop), which indicates the relative completeness of the
 task.
 
-### Example 2: Display the progress of nested For loops
+### Example 2: Display the progress of nested `for` loops
 
 ```powershell
 for($I = 0; $I -lt 10; $I++ ) {
@@ -80,7 +80,7 @@ Progress
 InnerLoop
 ```
 
-This example displays the progress of two nested For loops, each of which is represented by a
+This example displays the progress of two nested `for` loops, each of which is represented by a
 progress bar.
 
 The `Write-Progress` command for the second progress bar includes the **Id** parameter that
@@ -93,7 +93,7 @@ displayed one below the other.
 
 ```powershell
 # Use Get-EventLog to get the events in the System log and store them in the $Events variable.
-$Events = Get-EventLog -LogName system
+$Events = Get-EventLog -LogName System
 # Pipe the events to the ForEach-Object cmdlet.
 $Events | ForEach-Object -Begin {
     # In the Begin block, use Clear-Host to clear the screen.
@@ -104,7 +104,7 @@ $Events | ForEach-Object -Begin {
     $out = ""
 } -Process {
     # In the Process script block search the message property of each incoming object for "bios".
-    if($_.message -like "*bios*")
+    if($_.Message -like "*bios*")
     {
         # Append the matching message to the out variable.
         $out=$out + $_.Message
@@ -112,7 +112,7 @@ $Events | ForEach-Object -Begin {
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
     # Determine the completion percentage
-    $Completed = ($i/$Events.count) * 100
+    $Completed = ($i/$Events.Count) * 100
     # Use Write-Progress to output a progress bar.
     # The Activity and Status parameters create the first and second lines of the progress bar
     # heading, respectively.
@@ -126,7 +126,7 @@ $Events | ForEach-Object -Begin {
 This command displays the progress of a command to find the string "bios" in the System event log.
 
 The **PercentComplete** parameter value is calculated by dividing the number of events that have
-been processed `$i` by the total number of events retrieved `$Events.count` and then multiplying
+been processed `$i` by the total number of events retrieved `$Events.Count` and then multiplying
 that result by 100.
 
 ### Example 4: Display progress for each level of a nested process

--- a/reference/7.4/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -149,8 +149,8 @@ Get-History | Sort-Object -Property Id -Descending
    8 Get-Command Sort-Object -Syntax
    7 Get-Command Sort-Object -ShowCommandInfo
    6 Get-ChildItem -Path C:\Test | Sort-Object -Property Length
-   5 Get-Help Clear-History -online
-   4 Get-Help Clear-History -full
+   5 Get-Help Clear-History -Online
+   4 Get-Help Clear-History -Full
    3 Get-ChildItem | Get-Member
    2 Get-Command Sort-Object -Syntax
    1 Set-Location C:\Test\
@@ -590,8 +590,8 @@ use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
-- `expression` - `<string>` or `<script block>`
-- `ascending` or `descending` - `<boolean>`
+- `Expression` - `<string>` or `<script block>`
+- `Ascending` or `Descending` - `<boolean>`
 
 For more information, see
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md).

--- a/reference/7.4/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -67,7 +67,7 @@ This example gets a list of the processes running on the computer, saves them to
 variable, and pipes them to `Select-Object`.
 
 ```powershell
-Get-Process notepad | Tee-Object -Variable proc | Select-Object processname,handles
+Get-Process notepad | Tee-Object -Variable proc | Select-Object ProcessName, Handles
 ```
 
 ```Output
@@ -88,8 +88,8 @@ This example saves a list of system files in a two log files, a cumulative file 
 
 ```powershell
 Get-ChildItem -Path D: -File -System -Recurse |
-  Tee-Object -FilePath "c:\test\AllSystemFiles.txt" -Append |
-    Out-File c:\test\NewSystemFiles.txt
+  Tee-Object -FilePath "C:\test\AllSystemFiles.txt" -Append |
+    Out-File C:\test\NewSystemFiles.txt
 ```
 
 The command uses the `Get-ChildItem` cmdlet to do a recursive search for system files on the D:

--- a/reference/7.4/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -44,7 +44,7 @@ This example starts a trace of metadata processing, parameter binding, and cmdle
 destruction of the `Get-Process Notepad` expression.
 
 ```powershell
-Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+Trace-Command -Name Metadata, ParameterBinding, Cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
 It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify

--- a/reference/7.4/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -88,12 +88,12 @@ Stream                   Length
 Zone.Identifier              26
 
 PS C:\> C:\ps-test\Start-ActivityTracker.ps1
-c:\ps-test\Start-ActivityTracker.ps1 : File c:\ps-test\Start-ActivityTracker.ps1 cannot
-be loaded. The file c:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
+C:\ps-test\Start-ActivityTracker.ps1 : File C:\ps-test\Start-ActivityTracker.ps1 cannot
+be loaded. The file C:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
 will not execute on the system. For more information, see about_Execution_Policies.
 
 At line:1 char:1
-+ c:\ps-test\Start-ActivityTracker.ps1
++ C:\ps-test\Start-ActivityTracker.ps1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : SecurityError: (:) [], PSSecurityException
     + FullyQualifiedErrorId : UnauthorizedAccess

--- a/reference/7.4/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -52,11 +52,11 @@ This command reloads the formatting files that it loaded previously.
 ### Example 2: Reload formatting files and trace and log formatting files
 
 ```powershell
-Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
+Update-FormatData -AppendPath Trace.format.ps1xml, Log.format.ps1xml
 ```
 
 This command reloads the formatting files into the session, including two new files,
-Trace.format.ps1xml and Log.format.ps1xml.
+`Trace.format.ps1xml` and `Log.format.ps1xml`.
 
 Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
 after the formatting data from the built-in files.
@@ -67,7 +67,7 @@ are not referenced in the built-in files.
 ### Example 3: Edit a formatting file and reload it
 
 ```powershell
-Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+Update-FormatData -PrependPath "C:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
@@ -76,15 +76,15 @@ Update-FormatData
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+The first command adds the `NewFiles.format.ps1xml` file to the session. It uses the **PrependPath**
 parameter because the file contains formatting data for objects that are referenced in the built-in
 files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
-file.
+After adding the `NewFiles.format.ps1xml` file and testing it in these sessions, the author edits
+the file.
 
 The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
-NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+`NewFiles.format.ps1xml` file was previously loaded, `Update-FormatData` automatically reloads it
 without using parameters.
 
 ## PARAMETERS

--- a/reference/7.4/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Update-List.md
@@ -53,43 +53,43 @@ This cmdlet was reintroduced in PowerShell 7.
 
 In this example we create a class that represents a deck of cards where the cards are stored as a
 **List** collection object. The **NewDeck()** method uses `Update-List`to add a complete deck of
-card values to the **cards** collection.
+card values to the **Cards** collection.
 
 ```powershell
 class Cards {
 
-    [System.Collections.Generic.List[string]]$cards
-    [string]$name
+    [System.Collections.Generic.List[string]]$Cards
+    [string]$Name
 
     Cards([string]$_name) {
-        $this.name = $_name
-        $this.cards = [System.Collections.Generic.List[string]]::new()
+        $this.Name = $_name
+        $this.Cards = [System.Collections.Generic.List[string]]::new()
     }
 
     NewDeck() {
         $_suits = "`u{2663}","`u{2666}","`u{2665}","`u{2660}"
         $_values = 'A',2,3,4,5,6,7,8,9,10,'J','Q','K'
         $_deck = foreach ($s in $_suits){ foreach ($v in $_values){ "$v$s"} }
-        $this | Update-List -Property cards -Add $_deck | Out-Null
+        $this | Update-List -Property Cards -Add $_deck | Out-Null
     }
 
     Show() {
         Write-Host
-        Write-Host $this.name ": " $this.cards[0..12]
-        if ($this.cards.count -gt 13) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[13..25]
+        Write-Host $this.Name ": " $this.Cards[0..12]
+        if ($this.Cards.Count -gt 13) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[13..25]
         }
-        if ($this.cards.count -gt 26) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[26..38]
+        if ($this.Cards.Count -gt 26) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[26..38]
         }
-        if ($this.cards.count -gt 39) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[39..51]
+        if ($this.Cards.Count -gt 39) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[39..51]
         }
     }
 
-    Shuffle() { $this.cards = Get-Random -InputObject $this.cards -Count 52 }
+    Shuffle() { $this.Cards = Get-Random -InputObject $this.Cards -Count 52 }
 
-    Sort() { $this.cards.Sort() }
+    Sort() { $this.Cards.Sort() }
 }
 ```
 
@@ -113,10 +113,10 @@ $deck.Shuffle()
 $deck.Show()
 
 # Deal two hands
-$player1 | Update-List -Property cards -Add $deck.cards[0,2,4,6,8] | Out-Null
-$player2 | Update-List -Property cards -Add $deck.cards[1,3,5,7,9] | Out-Null
-$deck | Update-List -Property cards -Remove $player1.cards | Out-Null
-$deck | Update-List -Property cards -Remove $player2.cards | Out-Null
+$player1 | Update-List -Property Cards -Add $deck.Cards[0,2,4,6,8] | Out-Null
+$player2 | Update-List -Property Cards -Add $deck.Cards[1,3,5,7,9] | Out-Null
+$deck | Update-List -Property Cards -Remove $player1.Cards | Out-Null
+$deck | Update-List -Property Cards -Remove $player2.Cards | Out-Null
 
 $player1.Show()
 $player2.Show()
@@ -152,11 +152,11 @@ example, Player 1 wants to discard the `4♦` and `6♦` and get two new cards.
 
 ```powershell
 # Player 1 wants two new cards - remove 2 cards & add 2 cards
-$player1 | Update-List -Property cards -Remove $player1.cards[0,4] -Add $deck.cards[0..1] | Out-Null
+$player1 | Update-List -Property Cards -Remove $player1.Cards[0,4] -Add $deck.Cards[0..1] | Out-Null
 $player1.Show()
 
 # remove dealt cards from deck
-$deck | Update-List -Property cards -Remove $deck.cards[0..1] | Out-Null
+$deck | Update-List -Property Cards -Remove $deck.Cards[0..1] | Out-Null
 $deck.Show()
 ```
 
@@ -189,7 +189,7 @@ Remove                         {43}
 ```
 
 ```powershell
-([PSListModifier]($changeInstructions)).ApplyTo($list)
+([pslistmodifier]($changeInstructions)).ApplyTo($list)
 $list
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -153,7 +153,7 @@ when no properties are specified. Because the type data is not specified in a `T
 it is effective only in the current session.
 
 ```powershell
-Get-Date | Format-list
+Get-Date | Format-List
 
 Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet @(
     'DateTime'

--- a/reference/7.4/Microsoft.PowerShell.Utility/Wait-Debugger.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Wait-Debugger.md
@@ -49,7 +49,7 @@ function Test-Condition {
         [string]$Message = "Hello, $Name!"
     )
 
-    if ($Name -eq $env:USERNAME) {
+    if ($Name -eq $Env:USERNAME) {
         Write-Output "$Message"
     } else {
         # Remove after debugging
@@ -70,7 +70,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
 [DBG]: PS D:\>> l
 
     8:
-    9:      if ($Name -eq $env:USERNAME) {
+    9:      if ($Name -eq $Env:USERNAME) {
    10:          Write-Output "$Message"
    11:      } else {
    12:          # Remove after debugging
@@ -80,7 +80,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
    16:      }
    17:  }
 
-[DBG]: PS D:\>> $env:USERNAME
+[DBG]: PS D:\>> $Env:USERNAME
 User01
 [DBG]: PS D:\>> exit
 PS D:\>
@@ -113,7 +113,7 @@ class FileResource
 
     [void] Set() {
         $fileExists = $this.TestFilePath($this.Path)
-        if ($this.ensure -eq [Ensure]::Present) {
+        if ($this.Ensure -eq [Ensure]::Present) {
             if (! $fileExists) {
                $this.CopyFile()
             }

--- a/reference/7.4/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Write-Error.md
@@ -53,7 +53,7 @@ Non-terminating errors write an error to the error stream, but they don't stop c
 If a non-terminating error is declared on one item in a collection of input items, the command
 continues to process the other items in the collection.
 
-To declare a terminating error, use the `Throw` keyword.
+To declare a terminating error, use the `throw` keyword.
 For more information, see [about_Throw](../Microsoft.PowerShell.Core/About/about_Throw.md).
 
 ## EXAMPLES

--- a/reference/7.4/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -46,7 +46,7 @@ For more information about `$PSStyle`, see
 
 ## EXAMPLES
 
-### Example 1: Display the progress of a For loop
+### Example 1: Display the progress of a `for` loop
 
 ```powershell
 for ($i = 1; $i -le 100; $i++ ) {
@@ -61,7 +61,7 @@ The `Write-Progress` cmdlet includes a status bar heading `Activity`, a status l
 variable `$i` (the counter in the `for` loop), which indicates the relative completeness of the
 task.
 
-### Example 2: Display the progress of nested For loops
+### Example 2: Display the progress of nested `for` loops
 
 ```powershell
 $PSStyle.Progress.View = 'Classic'
@@ -117,7 +117,7 @@ being displayed one below the other.
 
 ```powershell
 # Use Get-WinEvent to get the events in the System log and store them in the $Events variable.
-$Events = Get-WinEvent -LogName system
+$Events = Get-WinEvent -LogName System
 # Pipe the events to the ForEach-Object cmdlet.
 $Events | ForEach-Object -Begin {
     # In the Begin block, use Clear-Host to clear the screen.
@@ -128,7 +128,7 @@ $Events | ForEach-Object -Begin {
     $out = ""
 } -Process {
     # In the Process script block search the message property of each incoming object for "bios".
-    if($_.message -like "*bios*")
+    if($_.Message -like "*bios*")
     {
         # Append the matching message to the out variable.
         $out=$out + $_.Message
@@ -136,7 +136,7 @@ $Events | ForEach-Object -Begin {
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
     # Determine the completion percentage
-    $Completed = ($i/$Events.count) * 100
+    $Completed = ($i/$Events.Count) * 100
     # Use Write-Progress to output a progress bar.
     # The Activity and Status parameters create the first and second lines of the progress bar
     # heading, respectively.
@@ -150,7 +150,7 @@ $Events | ForEach-Object -Begin {
 This command displays the progress of a command to find the string "bios" in the System event log.
 
 The **PercentComplete** parameter value is calculated by dividing the number of events that have
-been processed `$i` by the total number of events retrieved `$Events.count` and then multiplying
+been processed `$i` by the total number of events retrieved `$Events.Count` and then multiplying
 that result by 100.
 
 ### Example 4: Display progress for each level of a nested process

--- a/reference/7.5/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -149,8 +149,8 @@ Get-History | Sort-Object -Property Id -Descending
    8 Get-Command Sort-Object -Syntax
    7 Get-Command Sort-Object -ShowCommandInfo
    6 Get-ChildItem -Path C:\Test | Sort-Object -Property Length
-   5 Get-Help Clear-History -online
-   4 Get-Help Clear-History -full
+   5 Get-Help Clear-History -Online
+   4 Get-Help Clear-History -Full
    3 Get-ChildItem | Get-Member
    2 Get-Command Sort-Object -Syntax
    1 Set-Location C:\Test\
@@ -590,8 +590,8 @@ use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
-- `expression` - `<string>` or `<script block>`
-- `ascending` or `descending` - `<boolean>`
+- `Expression` - `<string>` or `<script block>`
+- `Ascending` or `Descending` - `<boolean>`
 
 For more information, see
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md).

--- a/reference/7.5/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -88,8 +88,8 @@ This example saves a list of system files in a two log files, a cumulative file 
 
 ```powershell
 Get-ChildItem -Path D: -File -System -Recurse |
-  Tee-Object -FilePath "c:\test\AllSystemFiles.txt" -Append |
-    Out-File c:\test\NewSystemFiles.txt
+  Tee-Object -FilePath "C:\test\AllSystemFiles.txt" -Append |
+    Out-File C:\test\NewSystemFiles.txt
 ```
 
 The command uses the `Get-ChildItem` cmdlet to do a recursive search for system files on the D:

--- a/reference/7.5/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -44,7 +44,7 @@ This example starts a trace of metadata processing, parameter binding, and cmdle
 destruction of the `Get-Process Notepad` expression.
 
 ```powershell
-Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+Trace-Command -Name Metadata, ParameterBinding, Cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
 It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify

--- a/reference/7.5/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -88,12 +88,12 @@ Stream                   Length
 Zone.Identifier              26
 
 PS C:\> C:\ps-test\Start-ActivityTracker.ps1
-c:\ps-test\Start-ActivityTracker.ps1 : File c:\ps-test\Start-ActivityTracker.ps1 cannot
-be loaded. The file c:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
+C:\ps-test\Start-ActivityTracker.ps1 : File C:\ps-test\Start-ActivityTracker.ps1 cannot
+be loaded. The file C:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
 will not execute on the system. For more information, see about_Execution_Policies.
 
 At line:1 char:1
-+ c:\ps-test\Start-ActivityTracker.ps1
++ C:\ps-test\Start-ActivityTracker.ps1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : SecurityError: (:) [], PSSecurityException
     + FullyQualifiedErrorId : UnauthorizedAccess

--- a/reference/7.5/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -52,11 +52,11 @@ This command reloads the formatting files that it loaded previously.
 ### Example 2: Reload formatting files and trace and log formatting files
 
 ```powershell
-Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
+Update-FormatData -AppendPath Trace.format.ps1xml, Log.format.ps1xml
 ```
 
 This command reloads the formatting files into the session, including two new files,
-Trace.format.ps1xml and Log.format.ps1xml.
+`Trace.format.ps1xml` and `Log.format.ps1xml`.
 
 Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
 after the formatting data from the built-in files.
@@ -67,7 +67,7 @@ are not referenced in the built-in files.
 ### Example 3: Edit a formatting file and reload it
 
 ```powershell
-Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+Update-FormatData -PrependPath "C:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
@@ -76,15 +76,15 @@ Update-FormatData
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+The first command adds the `NewFiles.format.ps1xml` file to the session. It uses the **PrependPath**
 parameter because the file contains formatting data for objects that are referenced in the built-in
 files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
-file.
+After adding the `NewFiles.format.ps1xml` file and testing it in these sessions, the author edits
+the file.
 
 The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
-NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+`NewFiles.format.ps1xml` file was previously loaded, `Update-FormatData` automatically reloads it
 without using parameters.
 
 ## PARAMETERS

--- a/reference/7.5/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Update-List.md
@@ -53,43 +53,43 @@ This cmdlet was reintroduced in PowerShell 7.
 
 In this example we create a class that represents a deck of cards where the cards are stored as a
 **List** collection object. The **NewDeck()** method uses `Update-List`to add a complete deck of
-card values to the **cards** collection.
+card values to the **Cards** collection.
 
 ```powershell
 class Cards {
 
-    [System.Collections.Generic.List[string]]$cards
-    [string]$name
+    [System.Collections.Generic.List[string]]$Cards
+    [string]$Name
 
     Cards([string]$_name) {
-        $this.name = $_name
-        $this.cards = [System.Collections.Generic.List[string]]::new()
+        $this.Name = $_name
+        $this.Cards = [System.Collections.Generic.List[string]]::new()
     }
 
     NewDeck() {
         $_suits = "`u{2663}","`u{2666}","`u{2665}","`u{2660}"
         $_values = 'A',2,3,4,5,6,7,8,9,10,'J','Q','K'
         $_deck = foreach ($s in $_suits){ foreach ($v in $_values){ "$v$s"} }
-        $this | Update-List -Property cards -Add $_deck | Out-Null
+        $this | Update-List -Property Cards -Add $_deck | Out-Null
     }
 
     Show() {
         Write-Host
-        Write-Host $this.name ": " $this.cards[0..12]
-        if ($this.cards.count -gt 13) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[13..25]
+        Write-Host $this.Name ": " $this.Cards[0..12]
+        if ($this.Cards.Count -gt 13) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[13..25]
         }
-        if ($this.cards.count -gt 26) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[26..38]
+        if ($this.Cards.Count -gt 26) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[26..38]
         }
-        if ($this.cards.count -gt 39) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[39..51]
+        if ($this.Cards.Count -gt 39) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[39..51]
         }
     }
 
-    Shuffle() { $this.cards = Get-Random -InputObject $this.cards -Count 52 }
+    Shuffle() { $this.Cards = Get-Random -InputObject $this.Cards -Count 52 }
 
-    Sort() { $this.cards.Sort() }
+    Sort() { $this.Cards.Sort() }
 }
 ```
 
@@ -113,10 +113,10 @@ $deck.Shuffle()
 $deck.Show()
 
 # Deal two hands
-$player1 | Update-List -Property cards -Add $deck.cards[0,2,4,6,8] | Out-Null
-$player2 | Update-List -Property cards -Add $deck.cards[1,3,5,7,9] | Out-Null
-$deck | Update-List -Property cards -Remove $player1.cards | Out-Null
-$deck | Update-List -Property cards -Remove $player2.cards | Out-Null
+$player1 | Update-List -Property Cards -Add $deck.Cards[0,2,4,6,8] | Out-Null
+$player2 | Update-List -Property Cards -Add $deck.Cards[1,3,5,7,9] | Out-Null
+$deck | Update-List -Property Cards -Remove $player1.Cards | Out-Null
+$deck | Update-List -Property Cards -Remove $player2.Cards | Out-Null
 
 $player1.Show()
 $player2.Show()
@@ -152,11 +152,11 @@ example, Player 1 wants to discard the `4♦` and `6♦` and get two new cards.
 
 ```powershell
 # Player 1 wants two new cards - remove 2 cards & add 2 cards
-$player1 | Update-List -Property cards -Remove $player1.cards[0,4] -Add $deck.cards[0..1] | Out-Null
+$player1 | Update-List -Property Cards -Remove $player1.Cards[0,4] -Add $deck.Cards[0..1] | Out-Null
 $player1.Show()
 
 # remove dealt cards from deck
-$deck | Update-List -Property cards -Remove $deck.cards[0..1] | Out-Null
+$deck | Update-List -Property Cards -Remove $deck.Cards[0..1] | Out-Null
 $deck.Show()
 ```
 
@@ -189,7 +189,7 @@ Remove                         {43}
 ```
 
 ```powershell
-([PSListModifier]($changeInstructions)).ApplyTo($list)
+([pslistmodifier]($changeInstructions)).ApplyTo($list)
 $list
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -153,7 +153,7 @@ when no properties are specified. Because the type data is not specified in a `T
 it is effective only in the current session.
 
 ```powershell
-Get-Date | Format-list
+Get-Date | Format-List
 
 Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet @(
     'DateTime'

--- a/reference/7.5/Microsoft.PowerShell.Utility/Wait-Debugger.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Wait-Debugger.md
@@ -49,7 +49,7 @@ function Test-Condition {
         [string]$Message = "Hello, $Name!"
     )
 
-    if ($Name -eq $env:USERNAME) {
+    if ($Name -eq $Env:USERNAME) {
         Write-Output "$Message"
     } else {
         # Remove after debugging
@@ -70,7 +70,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
 [DBG]: PS D:\>> l
 
     8:
-    9:      if ($Name -eq $env:USERNAME) {
+    9:      if ($Name -eq $Env:USERNAME) {
    10:          Write-Output "$Message"
    11:      } else {
    12:          # Remove after debugging
@@ -80,7 +80,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
    16:      }
    17:  }
 
-[DBG]: PS D:\>> $env:USERNAME
+[DBG]: PS D:\>> $Env:USERNAME
 User01
 [DBG]: PS D:\>> exit
 PS D:\>
@@ -114,7 +114,7 @@ class FileResource
 
     [void] Set() {
         $fileExists = $this.TestFilePath($this.Path)
-        if ($this.ensure -eq [Ensure]::Present) {
+        if ($this.Ensure -eq [Ensure]::Present) {
             if (! $fileExists) {
                $this.CopyFile()
             }

--- a/reference/7.5/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Write-Error.md
@@ -53,7 +53,7 @@ Non-terminating errors write an error to the error stream, but they don't stop c
 If a non-terminating error is declared on one item in a collection of input items, the command
 continues to process the other items in the collection.
 
-To declare a terminating error, use the `Throw` keyword.
+To declare a terminating error, use the `throw` keyword.
 For more information, see [about_Throw](../Microsoft.PowerShell.Core/About/about_Throw.md).
 
 ## EXAMPLES

--- a/reference/7.5/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -46,7 +46,7 @@ For more information about `$PSStyle`, see
 
 ## EXAMPLES
 
-### Example 1: Display the progress of a For loop
+### Example 1: Display the progress of a `for` loop
 
 ```powershell
 for ($i = 1; $i -le 100; $i++ ) {
@@ -61,7 +61,7 @@ The `Write-Progress` cmdlet includes a status bar heading `Activity`, a status l
 variable `$i` (the counter in the `for` loop), which indicates the relative completeness of the
 task.
 
-### Example 2: Display the progress of nested For loops
+### Example 2: Display the progress of nested `for` loops
 
 ```powershell
 $PSStyle.Progress.View = 'Classic'
@@ -117,7 +117,7 @@ being displayed one below the other.
 
 ```powershell
 # Use Get-WinEvent to get the events in the System log and store them in the $Events variable.
-$Events = Get-WinEvent -LogName system
+$Events = Get-WinEvent -LogName System
 # Pipe the events to the ForEach-Object cmdlet.
 $Events | ForEach-Object -Begin {
     # In the Begin block, use Clear-Host to clear the screen.
@@ -128,7 +128,7 @@ $Events | ForEach-Object -Begin {
     $out = ""
 } -Process {
     # In the Process script block search the message property of each incoming object for "bios".
-    if($_.message -like "*bios*")
+    if($_.Message -like "*bios*")
     {
         # Append the matching message to the out variable.
         $out=$out + $_.Message
@@ -136,7 +136,7 @@ $Events | ForEach-Object -Begin {
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
     # Determine the completion percentage
-    $Completed = ($i/$Events.count) * 100
+    $Completed = ($i/$Events.Count) * 100
     # Use Write-Progress to output a progress bar.
     # The Activity and Status parameters create the first and second lines of the progress bar
     # heading, respectively.
@@ -150,7 +150,7 @@ $Events | ForEach-Object -Begin {
 This command displays the progress of a command to find the string "bios" in the System event log.
 
 The **PercentComplete** parameter value is calculated by dividing the number of events that have
-been processed `$i` by the total number of events retrieved `$Events.count` and then multiplying
+been processed `$i` by the total number of events retrieved `$Events.Count` and then multiplying
 that result by 100.
 
 ### Example 4: Display progress for each level of a nested process

--- a/reference/7.6/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -149,8 +149,8 @@ Get-History | Sort-Object -Property Id -Descending
    8 Get-Command Sort-Object -Syntax
    7 Get-Command Sort-Object -ShowCommandInfo
    6 Get-ChildItem -Path C:\Test | Sort-Object -Property Length
-   5 Get-Help Clear-History -online
-   4 Get-Help Clear-History -full
+   5 Get-Help Clear-History -Online
+   4 Get-Help Clear-History -Full
    3 Get-ChildItem | Get-Member
    2 Get-Command Sort-Object -Syntax
    1 Set-Location C:\Test\
@@ -590,8 +590,8 @@ use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
-- `expression` - `<string>` or `<script block>`
-- `ascending` or `descending` - `<boolean>`
+- `Expression` - `<string>` or `<script block>`
+- `Ascending` or `Descending` - `<boolean>`
 
 For more information, see
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md).

--- a/reference/7.6/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -88,8 +88,8 @@ This example saves a list of system files in a two log files, a cumulative file 
 
 ```powershell
 Get-ChildItem -Path D: -File -System -Recurse |
-  Tee-Object -FilePath "c:\test\AllSystemFiles.txt" -Append |
-    Out-File c:\test\NewSystemFiles.txt
+  Tee-Object -FilePath "C:\test\AllSystemFiles.txt" -Append |
+    Out-File C:\test\NewSystemFiles.txt
 ```
 
 The command uses the `Get-ChildItem` cmdlet to do a recursive search for system files on the D:

--- a/reference/7.6/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -44,7 +44,7 @@ This example starts a trace of metadata processing, parameter binding, and cmdle
 destruction of the `Get-Process Notepad` expression.
 
 ```powershell
-Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+Trace-Command -Name Metadata, ParameterBinding, Cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
 It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify

--- a/reference/7.6/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -88,12 +88,12 @@ Stream                   Length
 Zone.Identifier              26
 
 PS C:\> C:\ps-test\Start-ActivityTracker.ps1
-c:\ps-test\Start-ActivityTracker.ps1 : File c:\ps-test\Start-ActivityTracker.ps1 cannot
-be loaded. The file c:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
+C:\ps-test\Start-ActivityTracker.ps1 : File C:\ps-test\Start-ActivityTracker.ps1 cannot
+be loaded. The file C:\ps-test\Start-ActivityTracker.ps1 is not digitally signed. The script
 will not execute on the system. For more information, see about_Execution_Policies.
 
 At line:1 char:1
-+ c:\ps-test\Start-ActivityTracker.ps1
++ C:\ps-test\Start-ActivityTracker.ps1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : SecurityError: (:) [], PSSecurityException
     + FullyQualifiedErrorId : UnauthorizedAccess

--- a/reference/7.6/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -52,11 +52,11 @@ This command reloads the formatting files that it loaded previously.
 ### Example 2: Reload formatting files and trace and log formatting files
 
 ```powershell
-Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
+Update-FormatData -AppendPath Trace.format.ps1xml, Log.format.ps1xml
 ```
 
 This command reloads the formatting files into the session, including two new files,
-Trace.format.ps1xml and Log.format.ps1xml.
+`Trace.format.ps1xml` and `Log.format.ps1xml`.
 
 Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
 after the formatting data from the built-in files.
@@ -67,7 +67,7 @@ are not referenced in the built-in files.
 ### Example 3: Edit a formatting file and reload it
 
 ```powershell
-Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+Update-FormatData -PrependPath "C:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
@@ -76,15 +76,15 @@ Update-FormatData
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+The first command adds the `NewFiles.format.ps1xml` file to the session. It uses the **PrependPath**
 parameter because the file contains formatting data for objects that are referenced in the built-in
 files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
-file.
+After adding the `NewFiles.format.ps1xml` file and testing it in these sessions, the author edits
+the file.
 
 The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
-NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+`NewFiles.format.ps1xml` file was previously loaded, `Update-FormatData` automatically reloads it
 without using parameters.
 
 ## PARAMETERS

--- a/reference/7.6/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Update-List.md
@@ -53,43 +53,43 @@ This cmdlet was reintroduced in PowerShell 7.
 
 In this example we create a class that represents a deck of cards where the cards are stored as a
 **List** collection object. The **NewDeck()** method uses `Update-List`to add a complete deck of
-card values to the **cards** collection.
+card values to the **Cards** collection.
 
 ```powershell
 class Cards {
 
-    [System.Collections.Generic.List[string]]$cards
-    [string]$name
+    [System.Collections.Generic.List[string]]$Cards
+    [string]$Name
 
     Cards([string]$_name) {
-        $this.name = $_name
-        $this.cards = [System.Collections.Generic.List[string]]::new()
+        $this.Name = $_name
+        $this.Cards = [System.Collections.Generic.List[string]]::new()
     }
 
     NewDeck() {
         $_suits = "`u{2663}","`u{2666}","`u{2665}","`u{2660}"
         $_values = 'A',2,3,4,5,6,7,8,9,10,'J','Q','K'
         $_deck = foreach ($s in $_suits){ foreach ($v in $_values){ "$v$s"} }
-        $this | Update-List -Property cards -Add $_deck | Out-Null
+        $this | Update-List -Property Cards -Add $_deck | Out-Null
     }
 
     Show() {
         Write-Host
-        Write-Host $this.name ": " $this.cards[0..12]
-        if ($this.cards.count -gt 13) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[13..25]
+        Write-Host $this.Name ": " $this.Cards[0..12]
+        if ($this.Cards.Count -gt 13) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[13..25]
         }
-        if ($this.cards.count -gt 26) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[26..38]
+        if ($this.Cards.Count -gt 26) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[26..38]
         }
-        if ($this.cards.count -gt 39) {
-            Write-Host (' ' * ($this.name.length+3)) $this.cards[39..51]
+        if ($this.Cards.Count -gt 39) {
+            Write-Host (' ' * ($this.Name.Length+3)) $this.Cards[39..51]
         }
     }
 
-    Shuffle() { $this.cards = Get-Random -InputObject $this.cards -Count 52 }
+    Shuffle() { $this.Cards = Get-Random -InputObject $this.Cards -Count 52 }
 
-    Sort() { $this.cards.Sort() }
+    Sort() { $this.Cards.Sort() }
 }
 ```
 
@@ -113,10 +113,10 @@ $deck.Shuffle()
 $deck.Show()
 
 # Deal two hands
-$player1 | Update-List -Property cards -Add $deck.cards[0,2,4,6,8] | Out-Null
-$player2 | Update-List -Property cards -Add $deck.cards[1,3,5,7,9] | Out-Null
-$deck | Update-List -Property cards -Remove $player1.cards | Out-Null
-$deck | Update-List -Property cards -Remove $player2.cards | Out-Null
+$player1 | Update-List -Property Cards -Add $deck.Cards[0,2,4,6,8] | Out-Null
+$player2 | Update-List -Property Cards -Add $deck.Cards[1,3,5,7,9] | Out-Null
+$deck | Update-List -Property Cards -Remove $player1.Cards | Out-Null
+$deck | Update-List -Property Cards -Remove $player2.Cards | Out-Null
 
 $player1.Show()
 $player2.Show()
@@ -152,11 +152,11 @@ example, Player 1 wants to discard the `4♦` and `6♦` and get two new cards.
 
 ```powershell
 # Player 1 wants two new cards - remove 2 cards & add 2 cards
-$player1 | Update-List -Property cards -Remove $player1.cards[0,4] -Add $deck.cards[0..1] | Out-Null
+$player1 | Update-List -Property Cards -Remove $player1.Cards[0,4] -Add $deck.Cards[0..1] | Out-Null
 $player1.Show()
 
 # remove dealt cards from deck
-$deck | Update-List -Property cards -Remove $deck.cards[0..1] | Out-Null
+$deck | Update-List -Property Cards -Remove $deck.Cards[0..1] | Out-Null
 $deck.Show()
 ```
 
@@ -189,7 +189,7 @@ Remove                         {43}
 ```
 
 ```powershell
-([PSListModifier]($changeInstructions)).ApplyTo($list)
+([pslistmodifier]($changeInstructions)).ApplyTo($list)
 $list
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -153,7 +153,7 @@ when no properties are specified. Because the type data is not specified in a `T
 it is effective only in the current session.
 
 ```powershell
-Get-Date | Format-list
+Get-Date | Format-List
 
 Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet @(
     'DateTime'

--- a/reference/7.6/Microsoft.PowerShell.Utility/Wait-Debugger.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Wait-Debugger.md
@@ -49,7 +49,7 @@ function Test-Condition {
         [string]$Message = "Hello, $Name!"
     )
 
-    if ($Name -eq $env:USERNAME) {
+    if ($Name -eq $Env:USERNAME) {
         Write-Output "$Message"
     } else {
         # Remove after debugging
@@ -70,7 +70,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
 [DBG]: PS D:\>> l
 
     8:
-    9:      if ($Name -eq $env:USERNAME) {
+    9:      if ($Name -eq $Env:USERNAME) {
    10:          Write-Output "$Message"
    11:      } else {
    12:          # Remove after debugging
@@ -80,7 +80,7 @@ At D:\temp\test\dbgtest.ps1:13 char:9
    16:      }
    17:  }
 
-[DBG]: PS D:\>> $env:USERNAME
+[DBG]: PS D:\>> $Env:USERNAME
 User01
 [DBG]: PS D:\>> exit
 PS D:\>
@@ -114,7 +114,7 @@ class FileResource
 
     [void] Set() {
         $fileExists = $this.TestFilePath($this.Path)
-        if ($this.ensure -eq [Ensure]::Present) {
+        if ($this.Ensure -eq [Ensure]::Present) {
             if (! $fileExists) {
                $this.CopyFile()
             }

--- a/reference/7.6/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Write-Error.md
@@ -53,7 +53,7 @@ Non-terminating errors write an error to the error stream, but they don't stop c
 If a non-terminating error is declared on one item in a collection of input items, the command
 continues to process the other items in the collection.
 
-To declare a terminating error, use the `Throw` keyword.
+To declare a terminating error, use the `throw` keyword.
 For more information, see [about_Throw](../Microsoft.PowerShell.Core/About/about_Throw.md).
 
 ## EXAMPLES

--- a/reference/7.6/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -46,7 +46,7 @@ For more information about `$PSStyle`, see
 
 ## EXAMPLES
 
-### Example 1: Display the progress of a For loop
+### Example 1: Display the progress of a `for` loop
 
 ```powershell
 for ($i = 1; $i -le 100; $i++ ) {
@@ -61,7 +61,7 @@ The `Write-Progress` cmdlet includes a status bar heading `Activity`, a status l
 variable `$i` (the counter in the `for` loop), which indicates the relative completeness of the
 task.
 
-### Example 2: Display the progress of nested For loops
+### Example 2: Display the progress of nested `for` loops
 
 ```powershell
 $PSStyle.Progress.View = 'Classic'
@@ -117,7 +117,7 @@ being displayed one below the other.
 
 ```powershell
 # Use Get-WinEvent to get the events in the System log and store them in the $Events variable.
-$Events = Get-WinEvent -LogName system
+$Events = Get-WinEvent -LogName System
 # Pipe the events to the ForEach-Object cmdlet.
 $Events | ForEach-Object -Begin {
     # In the Begin block, use Clear-Host to clear the screen.
@@ -128,7 +128,7 @@ $Events | ForEach-Object -Begin {
     $out = ""
 } -Process {
     # In the Process script block search the message property of each incoming object for "bios".
-    if($_.message -like "*bios*")
+    if($_.Message -like "*bios*")
     {
         # Append the matching message to the out variable.
         $out=$out + $_.Message
@@ -136,7 +136,7 @@ $Events | ForEach-Object -Begin {
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
     # Determine the completion percentage
-    $Completed = ($i/$Events.count) * 100
+    $Completed = ($i/$Events.Count) * 100
     # Use Write-Progress to output a progress bar.
     # The Activity and Status parameters create the first and second lines of the progress bar
     # heading, respectively.
@@ -150,7 +150,7 @@ $Events | ForEach-Object -Begin {
 This command displays the progress of a command to find the string "bios" in the System event log.
 
 The **PercentComplete** parameter value is calculated by dividing the number of events that have
-been processed `$i` by the total number of events retrieved `$Events.count` and then multiplying
+been processed `$i` by the total number of events retrieved `$Events.Count` and then multiplying
 that result by 100.
 
 ### Example 4: Display progress for each level of a nested process


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide