### PR TITLE
Fix incorrect case/capitalization in reference documents (28/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -65,7 +65,7 @@ command line. In this example, the name of the **FilePath** parameter, which is 
 ### Example 3: Get only valid Authenticode signatures for multiple files
 
 ```powershell
-Get-ChildItem $PSHOME\*.* | ForEach-object {Get-AuthenticodeSignature $_} | Where-Object {$_.status -eq "Valid"}
+Get-ChildItem $PSHOME\*.* | ForEach-Object {Get-AuthenticodeSignature $_} | Where-Object {$_.Status -eq "Valid"}
 ```
 
 This command lists all of the files in the `$PSHOME` directory that have a valid Authenticode

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -89,7 +89,7 @@ $Header = 'State', 'MoreData', 'StatusMessage', 'Location', 'Command',
           'BeginTime', 'EndTime', 'JobType', 'Output', 'Error', 'Progress',
           'Verbose', 'Debug', 'Warning', 'Information'
 # Delete the default header from $J
-$J = $J[1..($J.count - 1)]
+$J = $J[1..($J.Count - 1)]
 $J | ConvertFrom-Csv -Header $Header
 ```
 

--- a/reference/5.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/5.1/PSReadLine/About/about_PSReadLine.md
@@ -126,7 +126,7 @@ APIs are documented in [about_PSReadLine_Functions][02].
 PSReadLine maintains a history file containing all the commands and data you've
 entered from the command line. The history files are a file named
 `$($Host.Name)_history.txt`. On Windows systems the history file is stored at
-`$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`.
+`$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`.
 
 The history can contain sensitive data including passwords. PSReadLine attempts
 to filter out sensitive information. Any command lines containing the following
@@ -213,7 +213,7 @@ kubectl get secrets
 kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
 kubectl describe secret db-user-pass
 az account get-access-token --resource=https://app.contoso.com --query accessToken --output tsv
-$env:PGPASS = gcloud auth print-access-token
+$Env:PGPASS = gcloud auth print-access-token
 ```
 
 ### Feedback & contributing to PSReadLine

--- a/reference/5.1/PSReadLine/About/about_PSReadLine_Functions.md
+++ b/reference/5.1/PSReadLine/About/about_PSReadLine_Functions.md
@@ -1064,8 +1064,8 @@ chords.
 
 ### ViEditVisually
 
-Edit the command line in a text editor specified by `$env:EDITOR` or
-`$env:VISUAL`.
+Edit the command line in a text editor specified by `$Env:EDITOR` or
+`$Env:VISUAL`.
 
 - Emacs mode: `<Ctrl+x,Ctrl+e>`
 - Vi command mode: `<v>`

--- a/reference/5.1/PSReadLine/About/about_PSReadLine_Release_Notes.md
+++ b/reference/5.1/PSReadLine/About/about_PSReadLine_Release_Notes.md
@@ -183,7 +183,7 @@ release:
 - Supporting line-wise yanks, including paste and undo
 - Make `y0` yank up to the start of the logical line in `VI` mode
 - Add API to detect if the screen reader is active
-- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` windows only
+- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` Windows-only
 - Add script block vi mode indicator option
 - Support vi mode `G` and `gg` movements in multi-line buffers
 - Supports `_` and `$` to move to the beginning and end of the logical line in

--- a/reference/5.1/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/5.1/PSReadLine/Set-PSReadLineOption.md
@@ -130,10 +130,10 @@ This example emits a cursor change VT escape in response to a **Vi** mode change
 function OnViModeChange {
     if ($args[0] -eq 'Command') {
         # Set the cursor to a blinking block.
-        Write-Host -NoNewLine "$([char]0x1b)[1 q"
+        Write-Host -NoNewline "$([char]0x1b)[1 q"
     } else {
         # Set the cursor to a blinking line.
-        Write-Host -NoNewLine "$([char]0x1b)[5 q"
+        Write-Host -NoNewline "$([char]0x1b)[5 q"
     }
 }
 Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler $Function:OnViModeChange
@@ -153,9 +153,9 @@ to history.
 
 ```powershell
 $ScriptBlock = {
-    Param([string]$line)
+    param ([string]$Line)
 
-    if ($line -match "^git") {
+    if ($Line -match "^git") {
         return $false
     } else {
         return $true
@@ -520,7 +520,7 @@ platforms store the file in different locations. The filename is stored in a var
 
 If you don't use this parameter, the default path is:
 
-`$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
+`$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
 
 ```yaml
 Type: System.String
@@ -529,7 +529,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: A file named $($Host.Name)_history.txt in $env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
+Default value: A file named $($Host.Name)_history.txt in $Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $Env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -53,7 +53,7 @@ the system's pager command. PowerShell uses a different default pager for
 Windows and non-Windows systems. On Windows systems, the default pager is
 `more.com`. On non-Windows systems, the default pager is `less`.
 
-If the `$env:PAGER` environment variable is defined, PowerShell uses the
+If the `$Env:PAGER` environment variable is defined, PowerShell uses the
 specified program instead of the system default.
 
 ## `prompt`

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Calling_Generic_Methods.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Calling_Generic_Methods.md
@@ -22,7 +22,7 @@ overloads, or when the generic method takes no formal parameter. PowerShell can
 fail to resolve the correct method without the explicit generic method
 arguments.
 
-For example, `[Array]::Empty<T>()`. The .NET **Array** class has a static,
+For example, `[array]::Empty<T>()`. The .NET **Array** class has a static,
 generic method `Empty<T>()` that takes no formal parameters.
 
 Prior to PowerShell 7.3, to ensure proper method resolution you had to use
@@ -72,8 +72,8 @@ require two generic type parameters and two formal value parameters.
 $result = [System.Linq.Enumerable]::Select[int, float](
     $list,
     [Func[int, float]]{
-        param($item)
-        [math]::Pow($item, 3)
+        param($Item)
+        [Math]::Pow($Item, 3)
     }
 )
 $result

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
@@ -203,7 +203,7 @@ private key:
 
 ```powershell
 Get-WinEvent Microsoft-Windows-PowerShell/Operational |
-    Where-Object Id -eq 4104 | Unprotect-CmsMessage
+    Where-Object Id -EQ 4104 | Unprotect-CmsMessage
 ```
 
 ## See also

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -418,7 +418,7 @@ Example:
     "Transcription": {
         "EnableTranscripting": true,
         "EnableInvocationHeader": true,
-        "OutputDirectory": "c:\\tmp"
+        "OutputDirectory": "C:\\tmp"
       }
 }
 ```
@@ -436,7 +436,7 @@ Example:
 ```json
 {
     "UpdatableHelp": {
-      "DefaultSourcePath": "f:\\temp"
+      "DefaultSourcePath": "F:\\temp"
     }
 }
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -84,10 +84,10 @@ interpretation by the current shell. For example, if you are in `cmd.exe` and
 want to pass an environment variable value, you would use the `cmd.exe` syntax:
 `pwsh -File .\test.ps1 -TestParam %windir%`
 
-In contrast, running `pwsh -File .\test.ps1 -TestParam $env:windir` in
-`cmd.exe` results in the script receiving the literal string `$env:windir`
+In contrast, running `pwsh -File .\test.ps1 -TestParam $Env:windir` in
+`cmd.exe` results in the script receiving the literal string `$Env:windir`
 because it has no special meaning to the current `cmd.exe` shell. The
-`$env:windir` style of environment variable reference _can_ be used inside a
+`$Env:windir` style of environment variable reference _can_ be used inside a
 **Command** parameter, since there it's interpreted as PowerShell code.
 
 Similarly, if you want to execute the same command from a _Batch script_, you
@@ -138,7 +138,7 @@ expression, or parsed by the PowerShell host as a literal script block enclosed
 in curly braces (`{}`), before being passed to `pwsh`.
 
 ```powershell
-pwsh -Command {Get-WinEvent -LogName security}
+pwsh -Command {Get-WinEvent -LogName Security}
 ```
 
 In `cmd.exe`, there is no such thing as a script block (or **ScriptBlock**
@@ -153,7 +153,7 @@ running from `cmd.exe`. To execute an inline script block defined inside a
 string, the [call operator][03] `&` can be used:
 
 ```powershell
-pwsh -Command "& {Get-WinEvent -LogName security}"
+pwsh -Command "& {Get-WinEvent -LogName Security}"
 ```
 
 If the value of **Command** is a string, **Command** must be the last parameter
@@ -271,9 +271,9 @@ For example:
 
 ```powershell
 # PowerShell instance 1
-pwsh -CustomPipeName mydebugpipe
+pwsh -CustomPipeName MyDebugPipe
 # PowerShell instance 2
-Enter-PSHostProcess -CustomPipeName mydebugpipe
+Enter-PSHostProcess -CustomPipeName MyDebugPipe
 ```
 
 ### -EncodedCommand | -e | -ec
@@ -285,7 +285,7 @@ representation must be a UTF-16LE encoded string.
 For example:
 
 ```powershell
-$command = 'dir "c:\program files" '
+$command = 'dir "C:\Program Files" '
 $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
 $encodedCommand = [Convert]::ToBase64String($bytes)
 pwsh -EncodedCommand $encodedCommand
@@ -294,7 +294,7 @@ pwsh -EncodedCommand $encodedCommand
 ### -ExecutionPolicy | -ex | -ep
 
 Sets the default execution policy for the current session and saves it in the
-`$env:PSExecutionPolicyPreference` environment variable. This parameter does
+`$Env:PSExecutionPolicyPreference` environment variable. This parameter does
 not change the persistently configured execution policies.
 
 This parameter only applies to Windows computers. On non-Windows platforms, the
@@ -320,7 +320,7 @@ On Windows, this switch does nothing.
 > This parameter must come first to start PowerShell as a login shell. This
 > parameter is ignored if it is passed in another position.
 
-To set up `pwsh` as the login shell on UNIX-like operating systems:
+To set up `pwsh` as the login shell on Unix-like operating systems:
 
 - Verify that the full absolute path to `pwsh` is listed under `/etc/shells`
   - This path is usually something like `/usr/bin/pwsh` on Linux or
@@ -393,7 +393,7 @@ session. By default, system-wide settings are read from the
 Note that these settings aren't used by the endpoint specified by the
 `-ConfigurationName` argument.
 
-Example: `pwsh -SettingsFile c:\myproject\powershell.config.json`
+Example: `pwsh -SettingsFile C:\myproject\powershell.config.json`
 
 ### -SSHServerMode | -sshs
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Telemetry.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Telemetry.md
@@ -56,12 +56,12 @@ PowerShell sends this information periodically during the lifetime of the
 session for all host applications.
 
 To opt-out of this telemetry, set the environment variable
-`$env:POWERSHELL_TELEMETRY_OPTOUT` to `true`, `yes`, or `1`. For this
+`$Env:POWERSHELL_TELEMETRY_OPTOUT` to `true`, `yes`, or `1`. For this
 environment variable to have effect, it must be set before starting the
 PowerShell process. For more information, see
 [about_Environment_Variables][01].
 
-The `$env:POWERSHELL_DISTRIBUTION_CHANNEL` environment variable is set by the
+The `$Env:POWERSHELL_DISTRIBUTION_CHANNEL` environment variable is set by the
 installer packages to record the method and source of installation for
 PowerShell. Since this information is included in the telemetry data sent to
 Microsoft, users shouldn't change this value.

--- a/reference/7.4/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -67,7 +67,7 @@ command line. In this example, the name of the **FilePath** parameter, which is 
 ### Example 3: Get only valid Authenticode signatures for multiple files
 
 ```powershell
-Get-ChildItem $PSHOME\*.* | ForEach-object {Get-AuthenticodeSignature $_} | Where-Object {$_.status -eq "Valid"}
+Get-ChildItem $PSHOME\*.* | ForEach-Object {Get-AuthenticodeSignature $_} | Where-Object {$_.Status -eq "Valid"}
 ```
 
 This command lists all of the files in the `$PSHOME` directory that have a valid Authenticode

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -89,7 +89,7 @@ $Header = 'State', 'MoreData', 'StatusMessage', 'Location', 'Command',
           'BeginTime', 'EndTime', 'JobType', 'Output', 'Error', 'Progress',
           'Verbose', 'Debug', 'Warning', 'Information'
 # Delete the default header from $J
-$J = $J[1..($J.count - 1)]
+$J = $J[1..($J.Count - 1)]
 $J | ConvertFrom-Csv -Header $Header
 ```
 

--- a/reference/7.4/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.4/PSReadLine/About/about_PSReadLine.md
@@ -161,9 +161,9 @@ APIs are documented in [about_PSReadLine_Functions][02].
 PSReadLine maintains a history file containing all the commands and data you've
 entered from the command line. The history files are a file named
 `$($Host.Name)_history.txt`. On Windows systems the history file is stored at
-`$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`. On non-Windows systems,
-the history files are stored at `$env:XDG_DATA_HOME/powershell/PSReadLine` or
-`$env:HOME/.local/share/powershell/PSReadLine`.
+`$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`. On non-Windows systems,
+the history files are stored at `$Env:XDG_DATA_HOME/powershell/PSReadLine` or
+`$Env:HOME/.local/share/powershell/PSReadLine`.
 
 The history can contain sensitive data including passwords. PSReadLine attempts
 to filter out sensitive information. Any command lines containing the following
@@ -250,7 +250,7 @@ kubectl get secrets
 kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
 kubectl describe secret db-user-pass
 az account get-access-token --resource=https://app.contoso.com --query accessToken --output tsv
-$env:PGPASS = gcloud auth print-access-token
+$Env:PGPASS = gcloud auth print-access-token
 ```
 
 ### Feedback & contributing to PSReadLine

--- a/reference/7.4/PSReadLine/About/about_PSReadLine_Functions.md
+++ b/reference/7.4/PSReadLine/About/about_PSReadLine_Functions.md
@@ -1275,8 +1275,8 @@ chords.
 
 ### ViEditVisually
 
-Edit the command line in a text editor specified by `$env:EDITOR` or
-`$env:VISUAL`.
+Edit the command line in a text editor specified by `$Env:EDITOR` or
+`$Env:VISUAL`.
 
 - Emacs mode: `Ctrl+x,Ctrl+e`
 - Vi command mode: `<v>`

--- a/reference/7.4/PSReadLine/About/about_PSReadLine_Release_Notes.md
+++ b/reference/7.4/PSReadLine/About/about_PSReadLine_Release_Notes.md
@@ -183,7 +183,7 @@ release:
 - Supporting line-wise yanks, including paste and undo
 - Make `y0` yank up to the start of the logical line in `VI` mode
 - Add API to detect if the screen reader is active
-- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` windows only
+- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` Windows-only
 - Add script block vi mode indicator option
 - Support vi mode `G` and `gg` movements in multi-line buffers
 - Supports `_` and `$` to move to the beginning and end of the logical line in

--- a/reference/7.4/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Set-PSReadLineOption.md
@@ -131,10 +131,10 @@ This example emits a cursor change VT escape in response to a **Vi** mode change
 function OnViModeChange {
     if ($args[0] -eq 'Command') {
         # Set the cursor to a blinking block.
-        Write-Host -NoNewLine "`e[1 q"
+        Write-Host -NoNewline "`e[1 q"
     } else {
         # Set the cursor to a blinking line.
-        Write-Host -NoNewLine "`e[5 q"
+        Write-Host -NoNewline "`e[5 q"
     }
 }
 Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler $Function:OnViModeChange
@@ -154,9 +154,9 @@ to history.
 
 ```powershell
 $ScriptBlock = {
-    Param([string]$line)
+    param ([string]$Line)
 
-    if ($line -match "^git") {
+    if ($Line -match "^git") {
         return $false
     } else {
         return $true
@@ -533,11 +533,11 @@ If you don't use this parameter, the default path is as follows:
 
 **Windows**
 
-- `$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
+- `$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
 
 **non-Windows**
 
-- `$env:XDG_DATA_HOME/powershell/PSReadLine/$($Host.Name)_history.txt`
+- `$Env:XDG_DATA_HOME/powershell/PSReadLine/$($Host.Name)_history.txt`
 - `$HOME/.local/share/powershell/PSReadLine/$($Host.Name)_history.txt`
 
 ```yaml
@@ -547,7 +547,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: A file named $($Host.Name)_history.txt in $env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
+Default value: A file named $($Host.Name)_history.txt in $Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $Env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -53,7 +53,7 @@ the system's pager command. PowerShell uses a different default pager for
 Windows and non-Windows systems. On Windows systems, the default pager is
 `more.com`. On non-Windows systems, the default pager is `less`.
 
-If the `$env:PAGER` environment variable is defined, PowerShell uses the
+If the `$Env:PAGER` environment variable is defined, PowerShell uses the
 specified program instead of the system default.
 
 ## `prompt`

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Calling_Generic_Methods.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Calling_Generic_Methods.md
@@ -22,7 +22,7 @@ overloads, or when the generic method takes no formal parameter. PowerShell can
 fail to resolve the correct method without the explicit generic method
 arguments.
 
-For example, `[Array]::Empty<T>()`. The .NET **Array** class has a static,
+For example, `[array]::Empty<T>()`. The .NET **Array** class has a static,
 generic method `Empty<T>()` that takes no formal parameters.
 
 Prior to PowerShell 7.3, to ensure proper method resolution you had to use
@@ -72,8 +72,8 @@ require two generic type parameters and two formal value parameters.
 $result = [System.Linq.Enumerable]::Select[int, float](
     $list,
     [Func[int, float]]{
-        param($item)
-        [math]::Pow($item, 3)
+        param($Item)
+        [Math]::Pow($Item, 3)
     }
 )
 $result

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
@@ -203,7 +203,7 @@ private key:
 
 ```powershell
 Get-WinEvent Microsoft-Windows-PowerShell/Operational |
-    Where-Object Id -eq 4104 | Unprotect-CmsMessage
+    Where-Object Id -EQ 4104 | Unprotect-CmsMessage
 ```
 
 ## See also

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -419,7 +419,7 @@ Example:
     "Transcription": {
         "EnableTranscripting": true,
         "EnableInvocationHeader": true,
-        "OutputDirectory": "c:\\tmp"
+        "OutputDirectory": "C:\\tmp"
       }
 }
 ```
@@ -437,7 +437,7 @@ Example:
 ```json
 {
     "UpdatableHelp": {
-      "DefaultSourcePath": "f:\\temp"
+      "DefaultSourcePath": "F:\\temp"
     }
 }
 ```

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -84,10 +84,10 @@ interpretation by the current shell. For example, if you are in `cmd.exe` and
 want to pass an environment variable value, you would use the `cmd.exe` syntax:
 `pwsh -File .\test.ps1 -TestParam %windir%`
 
-In contrast, running `pwsh -File .\test.ps1 -TestParam $env:windir` in
-`cmd.exe` results in the script receiving the literal string `$env:windir`
+In contrast, running `pwsh -File .\test.ps1 -TestParam $Env:windir` in
+`cmd.exe` results in the script receiving the literal string `$Env:windir`
 because it has no special meaning to the current `cmd.exe` shell. The
-`$env:windir` style of environment variable reference _can_ be used inside a
+`$Env:windir` style of environment variable reference _can_ be used inside a
 **Command** parameter, since there it's interpreted as PowerShell code.
 
 Similarly, if you want to execute the same command from a _Batch script_, you
@@ -138,7 +138,7 @@ expression, or parsed by the PowerShell host as a literal script block enclosed
 in curly braces (`{}`), before being passed to `pwsh`.
 
 ```powershell
-pwsh -Command {Get-WinEvent -LogName security}
+pwsh -Command {Get-WinEvent -LogName Security}
 ```
 
 In `cmd.exe`, there is no such thing as a script block (or **ScriptBlock**
@@ -153,7 +153,7 @@ running from `cmd.exe`. To execute an inline script block defined inside a
 string, the [call operator][03] `&` can be used:
 
 ```powershell
-pwsh -Command "& {Get-WinEvent -LogName security}"
+pwsh -Command "& {Get-WinEvent -LogName Security}"
 ```
 
 If the value of **Command** is a string, **Command** must be the last parameter
@@ -272,9 +272,9 @@ For example:
 
 ```powershell
 # PowerShell instance 1
-pwsh -CustomPipeName mydebugpipe
+pwsh -CustomPipeName MyDebugPipe
 # PowerShell instance 2
-Enter-PSHostProcess -CustomPipeName mydebugpipe
+Enter-PSHostProcess -CustomPipeName MyDebugPipe
 ```
 
 ### -EncodedCommand | -e | -ec
@@ -286,7 +286,7 @@ representation must be a UTF-16LE encoded string.
 For example:
 
 ```powershell
-$command = 'dir "c:\program files" '
+$command = 'dir "C:\Program Files" '
 $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
 $encodedCommand = [Convert]::ToBase64String($bytes)
 pwsh -EncodedCommand $encodedCommand
@@ -295,7 +295,7 @@ pwsh -EncodedCommand $encodedCommand
 ### -ExecutionPolicy | -ex | -ep
 
 Sets the default execution policy for the current session and saves it in the
-`$env:PSExecutionPolicyPreference` environment variable. This parameter does
+`$Env:PSExecutionPolicyPreference` environment variable. This parameter does
 not change the persistently configured execution policies.
 
 This parameter only applies to Windows computers. On non-Windows platforms, the
@@ -321,7 +321,7 @@ On Windows, this switch does nothing.
 > This parameter must come first to start PowerShell as a login shell. This
 > parameter is ignored if it is passed in another position.
 
-To set up `pwsh` as the login shell on UNIX-like operating systems:
+To set up `pwsh` as the login shell on Unix-like operating systems:
 
 - Verify that the full absolute path to `pwsh` is listed under `/etc/shells`
   - This path is usually something like `/usr/bin/pwsh` on Linux or
@@ -394,7 +394,7 @@ session. By default, system-wide settings are read from the
 Note that these settings aren't used by the endpoint specified by the
 `-ConfigurationName` argument.
 
-Example: `pwsh -SettingsFile c:\myproject\powershell.config.json`
+Example: `pwsh -SettingsFile C:\myproject\powershell.config.json`
 
 ### -SSHServerMode | -sshs
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Telemetry.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Telemetry.md
@@ -62,12 +62,12 @@ PowerShell sends this information periodically during the lifetime of the
 session for all host applications.
 
 To opt-out of this telemetry, set the environment variable
-`$env:POWERSHELL_TELEMETRY_OPTOUT` to `true`, `yes`, or `1`. For this
+`$Env:POWERSHELL_TELEMETRY_OPTOUT` to `true`, `yes`, or `1`. For this
 environment variable to have effect, it must be set before starting the
 PowerShell process. For more information, see
 [about_Environment_Variables][01].
 
-The `$env:POWERSHELL_DISTRIBUTION_CHANNEL` environment variable is set by the
+The `$Env:POWERSHELL_DISTRIBUTION_CHANNEL` environment variable is set by the
 installer packages to record the method and source of installation for
 PowerShell. Since this information is included in the telemetry data sent to
 Microsoft, users shouldn't change this value.

--- a/reference/7.5/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.5/PSReadLine/About/about_PSReadLine.md
@@ -161,9 +161,9 @@ APIs are documented in [about_PSReadLine_Functions][02].
 PSReadLine maintains a history file containing all the commands and data you've
 entered from the command line. The history files are a file named
 `$($Host.Name)_history.txt`. On Windows systems the history file is stored at
-`$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`. On non-Windows systems,
-the history files are stored at `$env:XDG_DATA_HOME/powershell/PSReadLine` or
-`$env:HOME/.local/share/powershell/PSReadLine`.
+`$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`. On non-Windows systems,
+the history files are stored at `$Env:XDG_DATA_HOME/powershell/PSReadLine` or
+`$Env:HOME/.local/share/powershell/PSReadLine`.
 
 The history can contain sensitive data including passwords. PSReadLine attempts
 to filter out sensitive information. Any command lines containing the following
@@ -250,7 +250,7 @@ kubectl get secrets
 kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
 kubectl describe secret db-user-pass
 az account get-access-token --resource=https://app.contoso.com --query accessToken --output tsv
-$env:PGPASS = gcloud auth print-access-token
+$Env:PGPASS = gcloud auth print-access-token
 ```
 
 ### Feedback & contributing to PSReadLine

--- a/reference/7.5/PSReadLine/About/about_PSReadLine_Functions.md
+++ b/reference/7.5/PSReadLine/About/about_PSReadLine_Functions.md
@@ -1275,8 +1275,8 @@ chords.
 
 ### ViEditVisually
 
-Edit the command line in a text editor specified by `$env:EDITOR` or
-`$env:VISUAL`.
+Edit the command line in a text editor specified by `$Env:EDITOR` or
+`$Env:VISUAL`.
 
 - Emacs mode: `Ctrl+x,Ctrl+e`
 - Vi command mode: `<v>`

--- a/reference/7.5/PSReadLine/About/about_PSReadLine_Release_Notes.md
+++ b/reference/7.5/PSReadLine/About/about_PSReadLine_Release_Notes.md
@@ -183,7 +183,7 @@ release:
 - Supporting line-wise yanks, including paste and undo
 - Make `y0` yank up to the start of the logical line in `VI` mode
 - Add API to detect if the screen reader is active
-- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` windows only
+- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` Windows-only
 - Add script block vi mode indicator option
 - Support vi mode `G` and `gg` movements in multi-line buffers
 - Supports `_` and `$` to move to the beginning and end of the logical line in

--- a/reference/7.5/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.5/PSReadLine/Set-PSReadLineOption.md
@@ -131,10 +131,10 @@ This example emits a cursor change VT escape in response to a **Vi** mode change
 function OnViModeChange {
     if ($args[0] -eq 'Command') {
         # Set the cursor to a blinking block.
-        Write-Host -NoNewLine "`e[1 q"
+        Write-Host -NoNewline "`e[1 q"
     } else {
         # Set the cursor to a blinking line.
-        Write-Host -NoNewLine "`e[5 q"
+        Write-Host -NoNewline "`e[5 q"
     }
 }
 Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler $Function:OnViModeChange
@@ -154,9 +154,9 @@ to history.
 
 ```powershell
 $ScriptBlock = {
-    Param([string]$line)
+    param ([string]$Line)
 
-    if ($line -match "^git") {
+    if ($Line -match "^git") {
         return $false
     } else {
         return $true
@@ -533,11 +533,11 @@ If you don't use this parameter, the default path is as follows:
 
 **Windows**
 
-- `$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
+- `$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
 
 **non-Windows**
 
-- `$env:XDG_DATA_HOME/powershell/PSReadLine/$($Host.Name)_history.txt`
+- `$Env:XDG_DATA_HOME/powershell/PSReadLine/$($Host.Name)_history.txt`
 - `$HOME/.local/share/powershell/PSReadLine/$($Host.Name)_history.txt`
 
 ```yaml
@@ -547,7 +547,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: A file named $($Host.Name)_history.txt in $env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
+Default value: A file named $($Host.Name)_history.txt in $Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $Env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -53,7 +53,7 @@ the system's pager command. PowerShell uses a different default pager for
 Windows and non-Windows systems. On Windows systems, the default pager is
 `more.com`. On non-Windows systems, the default pager is `less`.
 
-If the `$env:PAGER` environment variable is defined, PowerShell uses the
+If the `$Env:PAGER` environment variable is defined, PowerShell uses the
 specified program instead of the system default.
 
 ## `prompt`

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Calling_Generic_Methods.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Calling_Generic_Methods.md
@@ -22,7 +22,7 @@ overloads, or when the generic method takes no formal parameter. PowerShell can
 fail to resolve the correct method without the explicit generic method
 arguments.
 
-For example, `[Array]::Empty<T>()`. The .NET **Array** class has a static,
+For example, `[array]::Empty<T>()`. The .NET **Array** class has a static,
 generic method `Empty<T>()` that takes no formal parameters.
 
 Prior to PowerShell 7.3, to ensure proper method resolution you had to use
@@ -72,8 +72,8 @@ require two generic type parameters and two formal value parameters.
 $result = [System.Linq.Enumerable]::Select[int, float](
     $list,
     [Func[int, float]]{
-        param($item)
-        [math]::Pow($item, 3)
+        param($Item)
+        [Math]::Pow($Item, 3)
     }
 )
 $result

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
@@ -203,7 +203,7 @@ private key:
 
 ```powershell
 Get-WinEvent Microsoft-Windows-PowerShell/Operational |
-    Where-Object Id -eq 4104 | Unprotect-CmsMessage
+    Where-Object Id -EQ 4104 | Unprotect-CmsMessage
 ```
 
 ## See also

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -419,7 +419,7 @@ Example:
     "Transcription": {
         "EnableTranscripting": true,
         "EnableInvocationHeader": true,
-        "OutputDirectory": "c:\\tmp"
+        "OutputDirectory": "C:\\tmp"
       }
 }
 ```
@@ -437,7 +437,7 @@ Example:
 ```json
 {
     "UpdatableHelp": {
-      "DefaultSourcePath": "f:\\temp"
+      "DefaultSourcePath": "F:\\temp"
     }
 }
 ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -84,10 +84,10 @@ interpretation by the current shell. For example, if you are in `cmd.exe` and
 want to pass an environment variable value, you would use the `cmd.exe` syntax:
 `pwsh -File .\test.ps1 -TestParam %windir%`
 
-In contrast, running `pwsh -File .\test.ps1 -TestParam $env:windir` in
-`cmd.exe` results in the script receiving the literal string `$env:windir`
+In contrast, running `pwsh -File .\test.ps1 -TestParam $Env:windir` in
+`cmd.exe` results in the script receiving the literal string `$Env:windir`
 because it has no special meaning to the current `cmd.exe` shell. The
-`$env:windir` style of environment variable reference _can_ be used inside a
+`$Env:windir` style of environment variable reference _can_ be used inside a
 **Command** parameter, since there it's interpreted as PowerShell code.
 
 Similarly, if you want to execute the same command from a _Batch script_, you
@@ -138,7 +138,7 @@ expression, or parsed by the PowerShell host as a literal script block enclosed
 in curly braces (`{}`), before being passed to `pwsh`.
 
 ```powershell
-pwsh -Command {Get-WinEvent -LogName security}
+pwsh -Command {Get-WinEvent -LogName Security}
 ```
 
 In `cmd.exe`, there is no such thing as a script block (or **ScriptBlock**
@@ -153,7 +153,7 @@ running from `cmd.exe`. To execute an inline script block defined inside a
 string, the [call operator][03] `&` can be used:
 
 ```powershell
-pwsh -Command "& {Get-WinEvent -LogName security}"
+pwsh -Command "& {Get-WinEvent -LogName Security}"
 ```
 
 If the value of **Command** is a string, **Command** must be the last parameter
@@ -272,9 +272,9 @@ For example:
 
 ```powershell
 # PowerShell instance 1
-pwsh -CustomPipeName mydebugpipe
+pwsh -CustomPipeName MyDebugPipe
 # PowerShell instance 2
-Enter-PSHostProcess -CustomPipeName mydebugpipe
+Enter-PSHostProcess -CustomPipeName MyDebugPipe
 ```
 
 ### -EncodedCommand | -e | -ec
@@ -286,7 +286,7 @@ representation must be a UTF-16LE encoded string.
 For example:
 
 ```powershell
-$command = 'dir "c:\program files" '
+$command = 'dir "C:\Program Files" '
 $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
 $encodedCommand = [Convert]::ToBase64String($bytes)
 pwsh -EncodedCommand $encodedCommand
@@ -295,7 +295,7 @@ pwsh -EncodedCommand $encodedCommand
 ### -ExecutionPolicy | -ex | -ep
 
 Sets the default execution policy for the current session and saves it in the
-`$env:PSExecutionPolicyPreference` environment variable. This parameter does
+`$Env:PSExecutionPolicyPreference` environment variable. This parameter does
 not change the persistently configured execution policies.
 
 This parameter only applies to Windows computers. On non-Windows platforms, the
@@ -321,7 +321,7 @@ On Windows, this switch does nothing.
 > This parameter must come first to start PowerShell as a login shell. This
 > parameter is ignored if it is passed in another position.
 
-To set up `pwsh` as the login shell on UNIX-like operating systems:
+To set up `pwsh` as the login shell on Unix-like operating systems:
 
 - Verify that the full absolute path to `pwsh` is listed under `/etc/shells`
   - This path is usually something like `/usr/bin/pwsh` on Linux or
@@ -394,7 +394,7 @@ session. By default, system-wide settings are read from the
 Note that these settings aren't used by the endpoint specified by the
 `-ConfigurationName` argument.
 
-Example: `pwsh -SettingsFile c:\myproject\powershell.config.json`
+Example: `pwsh -SettingsFile C:\myproject\powershell.config.json`
 
 ### -SSHServerMode | -sshs
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Telemetry.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Telemetry.md
@@ -63,12 +63,12 @@ PowerShell sends this information periodically during the lifetime of the
 session for all host applications.
 
 To opt-out of this telemetry, set the environment variable
-`$env:POWERSHELL_TELEMETRY_OPTOUT` to `true`, `yes`, or `1`. For this
+`$Env:POWERSHELL_TELEMETRY_OPTOUT` to `true`, `yes`, or `1`. For this
 environment variable to have effect, it must be set before starting the
 PowerShell process. For more information, see
 [about_Environment_Variables][01].
 
-The `$env:POWERSHELL_DISTRIBUTION_CHANNEL` environment variable is set by the
+The `$Env:POWERSHELL_DISTRIBUTION_CHANNEL` environment variable is set by the
 installer packages to record the method and source of installation for
 PowerShell. Since this information is included in the telemetry data sent to
 Microsoft, users shouldn't change this value.

--- a/reference/7.6/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/7.6/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -67,7 +67,7 @@ command line. In this example, the name of the **FilePath** parameter, which is 
 ### Example 3: Get only valid Authenticode signatures for multiple files
 
 ```powershell
-Get-ChildItem $PSHOME\*.* | ForEach-object {Get-AuthenticodeSignature $_} | Where-Object {$_.status -eq "Valid"}
+Get-ChildItem $PSHOME\*.* | ForEach-Object {Get-AuthenticodeSignature $_} | Where-Object {$_.Status -eq "Valid"}
 ```
 
 This command lists all of the files in the `$PSHOME` directory that have a valid Authenticode

--- a/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -89,7 +89,7 @@ $Header = 'State', 'MoreData', 'StatusMessage', 'Location', 'Command',
           'BeginTime', 'EndTime', 'JobType', 'Output', 'Error', 'Progress',
           'Verbose', 'Debug', 'Warning', 'Information'
 # Delete the default header from $J
-$J = $J[1..($J.count - 1)]
+$J = $J[1..($J.Count - 1)]
 $J | ConvertFrom-Csv -Header $Header
 ```
 

--- a/reference/7.6/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.6/PSReadLine/About/about_PSReadLine.md
@@ -161,9 +161,9 @@ APIs are documented in [about_PSReadLine_Functions][02].
 PSReadLine maintains a history file containing all the commands and data you've
 entered from the command line. The history files are a file named
 `$($Host.Name)_history.txt`. On Windows systems the history file is stored at
-`$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`. On non-Windows systems,
-the history files are stored at `$env:XDG_DATA_HOME/powershell/PSReadLine` or
-`$env:HOME/.local/share/powershell/PSReadLine`.
+`$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine`. On non-Windows systems,
+the history files are stored at `$Env:XDG_DATA_HOME/powershell/PSReadLine` or
+`$Env:HOME/.local/share/powershell/PSReadLine`.
 
 The history can contain sensitive data including passwords. PSReadLine attempts
 to filter out sensitive information. Any command lines containing the following
@@ -250,7 +250,7 @@ kubectl get secrets
 kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
 kubectl describe secret db-user-pass
 az account get-access-token --resource=https://app.contoso.com --query accessToken --output tsv
-$env:PGPASS = gcloud auth print-access-token
+$Env:PGPASS = gcloud auth print-access-token
 ```
 
 ### Feedback & contributing to PSReadLine

--- a/reference/7.6/PSReadLine/About/about_PSReadLine_Functions.md
+++ b/reference/7.6/PSReadLine/About/about_PSReadLine_Functions.md
@@ -1275,8 +1275,8 @@ chords.
 
 ### ViEditVisually
 
-Edit the command line in a text editor specified by `$env:EDITOR` or
-`$env:VISUAL`.
+Edit the command line in a text editor specified by `$Env:EDITOR` or
+`$Env:VISUAL`.
 
 - Emacs mode: `Ctrl+x,Ctrl+e`
 - Vi command mode: `<v>`

--- a/reference/7.6/PSReadLine/About/about_PSReadLine_Release_Notes.md
+++ b/reference/7.6/PSReadLine/About/about_PSReadLine_Release_Notes.md
@@ -183,7 +183,7 @@ release:
 - Supporting line-wise yanks, including paste and undo
 - Make `y0` yank up to the start of the logical line in `VI` mode
 - Add API to detect if the screen reader is active
-- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` windows only
+- Make `PageUp/PageDown` and `CtrlPageUp/CtrlPageDown` Windows-only
 - Add script block vi mode indicator option
 - Support vi mode `G` and `gg` movements in multi-line buffers
 - Supports `_` and `$` to move to the beginning and end of the logical line in

--- a/reference/7.6/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.6/PSReadLine/Set-PSReadLineOption.md
@@ -131,10 +131,10 @@ This example emits a cursor change VT escape in response to a **Vi** mode change
 function OnViModeChange {
     if ($args[0] -eq 'Command') {
         # Set the cursor to a blinking block.
-        Write-Host -NoNewLine "`e[1 q"
+        Write-Host -NoNewline "`e[1 q"
     } else {
         # Set the cursor to a blinking line.
-        Write-Host -NoNewLine "`e[5 q"
+        Write-Host -NoNewline "`e[5 q"
     }
 }
 Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler $Function:OnViModeChange
@@ -154,9 +154,9 @@ to history.
 
 ```powershell
 $ScriptBlock = {
-    Param([string]$line)
+    param ([string]$Line)
 
-    if ($line -match "^git") {
+    if ($Line -match "^git") {
         return $false
     } else {
         return $true
@@ -533,11 +533,11 @@ If you don't use this parameter, the default path is as follows:
 
 **Windows**
 
-- `$env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
+- `$Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine\$($Host.Name)_history.txt`
 
 **non-Windows**
 
-- `$env:XDG_DATA_HOME/powershell/PSReadLine/$($Host.Name)_history.txt`
+- `$Env:XDG_DATA_HOME/powershell/PSReadLine/$($Host.Name)_history.txt`
 - `$HOME/.local/share/powershell/PSReadLine/$($Host.Name)_history.txt`
 
 ```yaml
@@ -547,7 +547,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: A file named $($Host.Name)_history.txt in $env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
+Default value: A file named $($Host.Name)_history.txt in $Env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $Env:XDG_DATA_HOME/powershell/PSReadLine or $HOME/.local/share/powershell/PSReadLine on non-Windows platforms
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide