### PR TITLE
Fix incorrect case/capitalization in reference documents (32/38)

### DIFF
--- a/reference/docs-conceptual/community/2021-updates.md
+++ b/reference/docs-conceptual/community/2021-updates.md
@@ -258,7 +258,7 @@ New content
 
 Content updates
 
-- Converted [about_remote_faq](/powershell/scripting/learn/remoting/powershell-remoting-faq) to new
+- Converted [about_Remote_FAQ](/powershell/scripting/learn/remoting/powershell-remoting-faq) to new
   YAML format and moved to conceptual TOC
 - Moved **PSDesiredStateConfiguration** out of 7.2 docs and into PowerShell-Docs-Modules
   - DSC is being removed from PowerShell to become an optional module that is loaded from the

--- a/reference/docs-conceptual/community/community-update.yml
+++ b/reference/docs-conceptual/community/community-update.yml
@@ -8,7 +8,7 @@ metadata:
   description: A list of resources and a summary of new articles and community contributions. # < 160 chars
   ms.topic: landing-page # Required
   author: sdwheeler #Required; your GitHub user alias, with correct capitalization.
-  ms.author: sewhee #Required; microsoft alias of author; optional team alias.
+  ms.author: sewhee #Required; Microsoft alias of author; optional team alias.
   ms.date: 02/03/2025
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn |

--- a/reference/docs-conceptual/community/contributing/labelling-in-github.md
+++ b/reference/docs-conceptual/community/contributing/labelling-in-github.md
@@ -54,7 +54,7 @@ Area labels identify the parts of PowerShell or the documentation that the issue
 | `area-portability`       | Cross-platform compatibility.                                                            |
 | `area-powershellget`     | The [PowerShellGet][13] module.                                                          |
 | `area-providers`         | PowerShell providers.                                                                    |
-| `area-psreadline`        | The [PSReadline][14] module.                                                             |
+| `area-psreadline`        | The [PSReadLine][14] module.                                                             |
 | `area-release-notes`     | The PowerShell release notes.                                                            |
 | `area-remoting`          | The PowerShell remoting feature and cmdlets.                                             |
 | `area-scriptanalyzer`    | The [PSScriptAnalyzer][15] module.                                                       |

--- a/reference/docs-conceptual/dev-cross-plat/choosing-the-right-nuget-package.md
+++ b/reference/docs-conceptual/dev-cross-plat/choosing-the-right-nuget-package.md
@@ -168,7 +168,7 @@ as the root module).
 When it comes to testing your module in .NET test runners like xUnit, remember that compile-time
 checks can only go so far. You must test your module against the relevant PowerShell platforms.
 
-To test APIs built against PowerShell Standard in .NET, you should add `Microsoft.Powershell.SDK` as
+To test APIs built against PowerShell Standard in .NET, you should add `Microsoft.PowerShell.SDK` as
 a testing dependency with .NET Core (with the version set to match the desired PowerShell version),
 and the appropriate Windows PowerShell reference assemblies with .NET Framework.
 
@@ -187,24 +187,24 @@ PowerShell installations or libraries.
 > The PowerShell SDK just refers to all the component packages that make up PowerShell, and which
 > can be used for .NET development with PowerShell.
 
-A given `Microsoft.Powershell.SDK` version contains the concrete implementation of the same version
+A given `Microsoft.PowerShell.SDK` version contains the concrete implementation of the same version
 of the PowerShell application; version 7.0 contains the implementation of PowerShell 7.0 and running
 commands or scripts with it will largely behave like running them in PowerShell 7.0.
 
 Running PowerShell commands from the SDK is mostly, but not totally, the same as running them from
 `pwsh`. For example, [Start-Job][10] currently depends on the `pwsh` executable being available, and
-so will not work with `Microsoft.Powershell.SDK` by default.
+so will not work with `Microsoft.PowerShell.SDK` by default.
 
-Targeting `Microsoft.Powershell.SDK` from a .NET application allows you to integrate with all of
+Targeting `Microsoft.PowerShell.SDK` from a .NET application allows you to integrate with all of
 PowerShell's implementation assemblies, such as `System.Management.Automation`,
 `Microsoft.PowerShell.Management`, and other module assemblies.
 
-Publishing an application targeting `Microsoft.Powershell.SDK` will include all these assemblies,
+Publishing an application targeting `Microsoft.PowerShell.SDK` will include all these assemblies,
 and any dependencies PowerShell requires. It will also include other assets that PowerShell required
 in its build, such as the module manifests for `Microsoft.PowerShell.*` modules and the `ref`
 directory required by [Add-Type][11].
 
-Given the completeness of `Microsoft.Powershell.SDK`, it's best suited for:
+Given the completeness of `Microsoft.PowerShell.SDK`, it's best suited for:
 
 - Implementation of PowerShell hosts.
 - xUnit testing of libraries targeting PowerShell reference assemblies.
@@ -215,7 +215,7 @@ be used as a module or otherwise loaded by PowerShell, but depends on APIs only 
 particular version of PowerShell. Note that an assembly published against a specific version of
 `Microsoft.PowerShell.SDK` will only be safe to load and use in that version of PowerShell. To
 target multiple PowerShell versions with specific APIs, multiple builds are required, each targeting
-their own version of `Microsoft.Powershell.SDK`.
+their own version of `Microsoft.PowerShell.SDK`.
 
 > [!NOTE]
 > The PowerShell SDK is only available for PowerShell versions 6 and up. To provide equivalent
@@ -225,7 +225,7 @@ their own version of `Microsoft.Powershell.SDK`.
 ## System.Management.Automation
 
 The `System.Management.Automation` package is the heart of the PowerShell SDK. It exists on NuGet,
-primarily, as an asset for `Microsoft.Powershell.SDK` to pull in. However, it can also be used
+primarily, as an asset for `Microsoft.PowerShell.SDK` to pull in. However, it can also be used
 directly as a package for smaller hosting scenarios and version-targeting modules.
 
 Specifically, the `System.Management.Automation` package may be a preferable provider of PowerShell

--- a/reference/docs-conceptual/dev-cross-plat/create-feedback-provider.md
+++ b/reference/docs-conceptual/dev-cross-plat/create-feedback-provider.md
@@ -449,7 +449,7 @@ Import-Module ./bin/Debug/net8.0/myFeedbackProvider
 ```
 
 Once you're satisfied with your module, you should create a module manifest, publish it to the
-PowerShell Gallery, and install it in your `$env:PSModulePath`. For more information, see
+PowerShell Gallery, and install it in your `$Env:PSModulePath`. For more information, see
 [How to create a module manifest][01]. You can add the `Import-Module` command to your `$PROFILE`
 script so the module is available in PowerShell session.
 

--- a/reference/docs-conceptual/dev-cross-plat/create-standard-library-binary-Module.md
+++ b/reference/docs-conceptual/dev-cross-plat/create-standard-library-binary-Module.md
@@ -282,7 +282,7 @@ At this point, we can import our module with the psd1 file.
 Import-Module ".\Output\$module\$module.psd1"
 ```
 
-From here, we can drop the `.\Output\$module` folder into our `$env:PSModulePath` directory and it
+From here, we can drop the `.\Output\$module` folder into our `$Env:PSModulePath` directory and it
 autoloads our command whenever we need it.
 
 ### Update: dotnet new PSModule

--- a/reference/docs-conceptual/dev-cross-plat/performance/script-authoring-considerations.md
+++ b/reference/docs-conceptual/dev-cross-plat/performance/script-authoring-considerations.md
@@ -62,7 +62,7 @@ $tests = @{
         [pscustomobject]@{
             Iterations        = $_
             Test              = $test.Key
-            TotalMilliseconds = [math]::Round($ms, 2)
+            TotalMilliseconds = [Math]::Round($ms, 2)
         }
 
         [GC]::Collect()
@@ -74,7 +74,7 @@ $tests = @{
         Name       = 'RelativeSpeed'
         Expression = {
             $relativeSpeed = $_.TotalMilliseconds / $groupResult[0].TotalMilliseconds
-            [math]::Round($relativeSpeed, 2).ToString() + 'x'
+            [Math]::Round($relativeSpeed, 2).ToString() + 'x'
         }
     }
 }
@@ -122,7 +122,7 @@ There are a couple of alternatives. If you don't actually require an array, inst
 a typed generic list (`[List<T>]`):
 
 ```powershell
-$results = [System.Collections.Generic.List[object]]::new()
+$results = [System.Collections.Generic.List[Object]]::new()
 $results.AddRange((Get-Something))
 $results.AddRange((Get-SomethingElse))
 $results
@@ -136,25 +136,25 @@ as the baseline for performance.
 ```powershell
 $tests = @{
     'PowerShell Explicit Assignment' = {
-        param($count)
+        param($Count)
 
-        $result = foreach($i in 1..$count) {
+        $result = foreach($i in 1..$Count) {
             $i
         }
     }
     '.Add(T) to List<T>' = {
-        param($count)
+        param($Count)
 
         $result = [Collections.Generic.List[int]]::new()
-        foreach($i in 1..$count) {
+        foreach($i in 1..$Count) {
             $result.Add($i)
         }
     }
     '+= Operator to Array' = {
-        param($count)
+        param($Count)
 
         $result = @()
-        foreach($i in 1..$count) {
+        foreach($i in 1..$Count) {
             $result += $i
         }
     }
@@ -167,7 +167,7 @@ $tests = @{
         [pscustomobject]@{
             CollectionSize    = $_
             Test              = $test.Key
-            TotalMilliseconds = [math]::Round($ms, 2)
+            TotalMilliseconds = [Math]::Round($ms, 2)
         }
 
         [GC]::Collect()
@@ -179,7 +179,7 @@ $tests = @{
         Name       = 'RelativeSpeed'
         Expression = {
             $relativeSpeed = $_.TotalMilliseconds / $groupResult[0].TotalMilliseconds
-            [math]::Round($relativeSpeed, 2).ToString() + 'x'
+            [Math]::Round($relativeSpeed, 2).ToString() + 'x'
         }
     }
 }
@@ -204,8 +204,8 @@ CollectionSize Test                           TotalMilliseconds RelativeSpeed
 When you're working with large collections, array addition is dramatically slower than adding to
 a **`List<T>`**.
 
-When using a `[List<T>]` object, you need to create the list with a specific type, like `[String]`
-or `[Int]`. When you add objects of a different type to the list, they are cast to the specified
+When using a `[List<T>]` object, you need to create the list with a specific type, like `[string]`
+or `[int]`. When you add objects of a different type to the list, they are cast to the specified
 type. If they can't be cast to the specified type, the method raises an exception.
 
 ```powershell
@@ -235,7 +235,7 @@ When you need the list to be a collection of different types of objects, create 
 as the list type. You can enumerate the collection inspect the types of the objects in it.
 
 ```powershell
-$objectList = [System.Collections.Generic.List[object]]::new()
+$objectList = [System.Collections.Generic.List[Object]]::new()
 $objectList.Add(1)
 $objectList.Add('2')
 $objectList.Add(3.0)
@@ -309,7 +309,7 @@ $tests = @{
         [pscustomobject]@{
             Iterations        = $_
             Test              = $test.Key
-            TotalMilliseconds = [math]::Round($ms, 2)
+            TotalMilliseconds = [Math]::Round($ms, 2)
         }
 
         [GC]::Collect()
@@ -321,7 +321,7 @@ $tests = @{
         Name       = 'RelativeSpeed'
         Expression = {
             $relativeSpeed = $_.TotalMilliseconds / $groupResult[0].TotalMilliseconds
-            [math]::Round($relativeSpeed, 2).ToString() + 'x'
+            [Math]::Round($relativeSpeed, 2).ToString() + 'x'
         }
     }
 }
@@ -393,25 +393,25 @@ like using a name to retrieve an ID from one list and an email from another. Ite
 first list to find the matching record in the second collection is slow. In particular, the
 repeated filtering of the second collection has a large overhead.
 
-Given two collections, one with an **ID** and **Name**, the other with **Name** and **Email**:
+Given two collections, one with an **Id** and **Name**, the other with **Name** and **Email**:
 
 ```powershell
 $Employees = 1..10000 | ForEach-Object {
-    [PSCustomObject]@{
+    [pscustomobject]@{
         Id   = $_
         Name = "Name$_"
     }
 }
 
 $Accounts = 2500..7500 | ForEach-Object {
-    [PSCustomObject]@{
+    [pscustomobject]@{
         Name  = "Name$_"
         Email = "Name$_@fabrikam.com"
     }
 }
 ```
 
-The usual way to reconcile these collections to return a list of objects with the **ID**, **Name**,
+The usual way to reconcile these collections to return a list of objects with the **Id**, **Name**,
 and **Email** properties might look like this:
 
 ```powershell
@@ -501,39 +501,39 @@ $tests = @{
         param([int] $RepeatCount, [random] $RanGen)
 
         function Get-RandomNumberCore {
-            param ($rng)
+            param ($Rng)
 
-            $rng.Next()
+            $Rng.Next()
         }
 
         for ($i = 0; $i -lt $RepeatCount; $i++) {
-            $null = Get-RandomNumberCore -rng $RanGen
+            $null = Get-RandomNumberCore -Rng $RanGen
         }
     }
     'for-loop in a function' = {
         param([int] $RepeatCount, [random] $RanGen)
 
         function Get-RandomNumberAll {
-            param ($rng, $count)
+            param ($Rng, $Count)
 
-            for ($i = 0; $i -lt $count; $i++) {
-                $null = $rng.Next()
+            for ($i = 0; $i -lt $Count; $i++) {
+                $null = $Rng.Next()
             }
         }
 
-        Get-RandomNumberAll -rng $RanGen -count $RepeatCount
+        Get-RandomNumberAll -Rng $RanGen -Count $RepeatCount
     }
 }
 
 5kb, 10kb, 100kb | ForEach-Object {
-    $rng = [random]::new()
+    $Rng = [random]::new()
     $groupResult = foreach ($test in $tests.GetEnumerator()) {
-        $ms = Measure-Command { & $test.Value -RepeatCount $_ -RanGen $rng }
+        $ms = Measure-Command { & $test.Value -RepeatCount $_ -RanGen $Rng }
 
         [pscustomobject]@{
             CollectionSize    = $_
             Test              = $test.Key
-            TotalMilliseconds = [math]::Round($ms.TotalMilliseconds,2)
+            TotalMilliseconds = [Math]::Round($ms.TotalMilliseconds,2)
         }
 
         [GC]::Collect()
@@ -545,7 +545,7 @@ $tests = @{
         Name       = 'RelativeSpeed'
         Expression = {
             $relativeSpeed = $_.TotalMilliseconds / $groupResult[0].TotalMilliseconds
-            [math]::Round($relativeSpeed, 2).ToString() + 'x'
+            [Math]::Round($relativeSpeed, 2).ToString() + 'x'
         }
     }
 }
@@ -589,7 +589,7 @@ iteration of the `ForEach-Object` loop.
 ```powershell
 $measure = Measure-Command -Expression {
     Import-Csv .\Input.csv | ForEach-Object -Begin { $Id = 1 } -Process {
-        [PSCustomObject]@{
+        [pscustomobject]@{
             Id   = $Id
             Name = $_.opened_by
         } | Export-Csv .\Output1.csv -Append
@@ -610,7 +610,7 @@ In this case, `Export-Csv` is invoked only once, but still processes all objects
 ```powershell
 $measure = Measure-Command -Expression {
     Import-Csv .\Input.csv | ForEach-Object -Begin { $Id = 2 } -Process {
-        [PSCustomObject]@{
+        [pscustomobject]@{
             Id   = $Id
             Name = $_.opened_by
         }
@@ -637,7 +637,7 @@ accelerator.
 Measure-Command {
     $test = 'PSCustomObject'
     for ($i = 0; $i -lt 100000; $i++) {
-        $resultObject = [PSCustomObject]@{
+        $resultObject = [pscustomobject]@{
             Name = 'Name'
             Path = 'FullName'
         }
@@ -647,7 +647,7 @@ Measure-Command {
 Measure-Command {
     $test = 'New-Object'
     for ($i = 0; $i -lt 100000; $i++) {
-        $resultObject = New-Object -TypeName PSObject -Property @{
+        $resultObject = New-Object -TypeName psobject -Property @{
             Name = 'Name'
             Path = 'FullName'
         }
@@ -779,38 +779,38 @@ Here is a performance comparison of three techniques for creating objects with 5
 ```powershell
 $tests = @{
     '[ordered] into [pscustomobject] cast' = {
-        param([int] $iterations, [string[]] $props)
+        param([int] $Iterations, [string[]] $Props)
 
-        foreach ($i in 1..$iterations) {
+        foreach ($i in 1..$Iterations) {
             $obj = [ordered]@{}
-            foreach ($prop in $props) {
+            foreach ($prop in $Props) {
                 $obj[$prop] = $i
             }
             [pscustomobject] $obj
         }
     }
     'Add-Member'                           = {
-        param([int] $iterations, [string[]] $props)
+        param([int] $Iterations, [string[]] $Props)
 
-        foreach ($i in 1..$iterations) {
+        foreach ($i in 1..$Iterations) {
             $obj = [psobject]::new()
-            foreach ($prop in $props) {
+            foreach ($prop in $Props) {
                 $obj | Add-Member -MemberType NoteProperty -Name $prop -Value $i
             }
             $obj
         }
     }
     'PSObject.Properties.Add'              = {
-        param([int] $iterations, [string[]] $props)
+        param([int] $Iterations, [string[]] $Props)
 
         # this is how, behind the scenes, `Add-Member` attaches
         # new properties to our PSObject.
         # Worth having it here for performance comparison
 
-        foreach ($i in 1..$iterations) {
+        foreach ($i in 1..$Iterations) {
             $obj = [psobject]::new()
-            foreach ($prop in $props) {
-                $obj.PSObject.Properties.Add(
+            foreach ($prop in $Props) {
+                $obj.psobject.Properties.Add(
                     [psnoteproperty]::new($prop, $i))
             }
             $obj
@@ -822,12 +822,12 @@ $properties = 'Prop1', 'Prop2', 'Prop3', 'Prop4', 'Prop5'
 
 1kb, 10kb, 100kb | ForEach-Object {
     $groupResult = foreach ($test in $tests.GetEnumerator()) {
-        $ms = Measure-Command { & $test.Value -iterations $_ -props $properties }
+        $ms = Measure-Command { & $test.Value -Iterations $_ -Props $properties }
 
         [pscustomobject]@{
             Iterations        = $_
             Test              = $test.Key
-            TotalMilliseconds = [math]::Round($ms.TotalMilliseconds, 2)
+            TotalMilliseconds = [Math]::Round($ms.TotalMilliseconds, 2)
         }
 
         [GC]::Collect()
@@ -839,7 +839,7 @@ $properties = 'Prop1', 'Prop2', 'Prop3', 'Prop4', 'Prop5'
         Name       = 'RelativeSpeed'
         Expression = {
             $relativeSpeed = $_.TotalMilliseconds / $groupResult[0].TotalMilliseconds
-            [math]::Round($relativeSpeed, 2).ToString() + 'x'
+            [Math]::Round($relativeSpeed, 2).ToString() + 'x'
         }
     }
 }
@@ -868,8 +868,8 @@ Iterations Test                                 TotalMilliseconds RelativeSpeed
 - [Out-Null][05]
 - [`List<T>`][06]
 - [`Add(T)` method][07]
-- [`[String]`][08]
-- [`[Int]`][09]
+- [`[string]`][08]
+- [`[int]`][09]
 - [`[Object]`][10]
 - [`ToArray()` method][11]
 - [`[ArrayList]`][12]

--- a/reference/docs-conceptual/dev-cross-plat/vscode/understanding-file-encoding.md
+++ b/reference/docs-conceptual/dev-cross-plat/vscode/understanding-file-encoding.md
@@ -253,7 +253,7 @@ If you need to re-encode multiple files, you can use the following script:
 ```powershell
 Get-ChildItem *.ps1 -Recurse | ForEach-Object {
     $content = Get-Content -Path $_
-    Set-Content -Path $_.Fullname -Value $content -Encoding UTF8 -PassThru -Force
+    Set-Content -Path $_.FullName -Value $content -Encoding UTF8 -PassThru -Force
 }
 ```
 

--- a/reference/docs-conceptual/developer/cmdlet/adding-aliases-wildcard-expansion-and-help-to-cmdlet-parameters.md
+++ b/reference/docs-conceptual/developer/cmdlet/adding-aliases-wildcard-expansion-and-help-to-cmdlet-parameters.md
@@ -18,7 +18,7 @@ This `Stop-Proc` cmdlet attempts to stop processes that are retrieved using the 
 The first step in cmdlet creation is always naming the cmdlet and declaring the .NET class that
 implements the cmdlet. Because you are writing a cmdlet to change the system, it should be named
 accordingly. Because this cmdlet stops system processes, it uses the verb **Stop**, defined by the
-[System.Management.Automation.Verbslifecycle](/dotnet/api/System.Management.Automation.VerbsLifeCycle)
+[System.Management.Automation.VerbsLifecycle](/dotnet/api/System.Management.Automation.VerbsLifecycle)
 class, with the noun **Proc** to indicate process. For more information about approved cmdlet verbs,
 see [Cmdlet Verb Names](./approved-verbs-for-windows-powershell-commands.md).
 
@@ -43,7 +43,7 @@ the system by some sort of identifier. In addition, the cmdlet should define the
 A parameter alias can be an alternate name or a well-defined 1-letter or 2-letter short name for a
 cmdlet parameter. In both cases, the goal of using aliases is to simplify user entry from the
 command line. Windows PowerShell supports parameter aliases through the
-[System.Management.Automation.Aliasattribute](/dotnet/api/System.Management.Automation.AliasAttribute)
+[System.Management.Automation.AliasAttribute](/dotnet/api/System.Management.Automation.AliasAttribute)
 attribute, which uses the declaration syntax `[Alias()]`.
 
 The following code shows how an alias is added to the **Name** parameter.
@@ -70,7 +70,7 @@ private string[] processNames;
 ```
 
 In addition to using the
-[System.Management.Automation.Aliasattribute](/dotnet/api/System.Management.Automation.AliasAttribute)
+[System.Management.Automation.AliasAttribute](/dotnet/api/System.Management.Automation.AliasAttribute)
 attribute, the Windows PowerShell runtime performs partial name matching, even if no aliases are
 specified. For example, if your cmdlet has a **FileName** parameter and that is the only parameter
 that starts with `F`, the user could enter `Filename`, `Filenam`, `File`, `Fi`, or `F` and still
@@ -81,7 +81,7 @@ recognize the entry as the **FileName** parameter.
 Windows PowerShell allows you to create Help for cmdlet parameters. Do this for any parameter used
 for system modification and user feedback. For each parameter to support Help, you can set the
 **HelpMessage** attribute keyword in the
-[System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
+[System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
 attribute declaration. This keyword defines the text to display to the user for assistance in using
 the parameter. You can also set the **HelpMessageBaseName** keyword to identify the base name of a
 resource to use for the message. If you set this keyword, you must also set the
@@ -174,7 +174,7 @@ For the complete C# sample code, see [StopProcessSample03 Sample](./stopprocesss
 
 ## Define Object Types and Formatting
 
-Windows PowerShell passes information between cmdlets using .Net objects. Consequently, a cmdlet may
+Windows PowerShell passes information between cmdlets using .NET objects. Consequently, a cmdlet may
 need to define its own type, or the cmdlet may need to extend an existing type provided by another
 cmdlet. For more information about defining new types or extending existing types, see
 [Extending Object Types and Formatting](/previous-versions//ms714665(v=vs.85)).

--- a/reference/docs-conceptual/developer/cmdlet/adding-non-terminating-error-reporting-to-your-cmdlet.md
+++ b/reference/docs-conceptual/developer/cmdlet/adding-non-terminating-error-reporting-to-your-cmdlet.md
@@ -228,15 +228,15 @@ line. Let's test the sample Get-Proc cmdlet to see whether it reports an error:
 - Start PowerShell, and use the Get-Proc cmdlet to retrieve the processes named "TEST".
 
   ```powershell
-  get-proc -name test
+  Get-Proc -Name test
   ```
 
   The following output appears.
 
   ```
-  get-proc : Operation is not valid due to the current state of the object.
+  Get-Proc : Operation is not valid due to the current state of the object.
   At line:1 char:9
-  + get-proc  <<<< -name test
+  + Get-Proc  <<<< -Name test
   ```
 
 ## See Also

--- a/reference/docs-conceptual/developer/cmdlet/adding-parameter-sets-to-a-cmdlet.md
+++ b/reference/docs-conceptual/developer/cmdlet/adding-parameter-sets-to-a-cmdlet.md
@@ -71,7 +71,7 @@ last two parameters, see
 
 This input parameter allows the user to specify the names of the processes to be stopped. Note that
 the `ParameterSetName` attribute keyword of the
-[System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
+[System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
 attribute specifies the `ProcessName` parameter set for this parameter.
 
 :::code language="csharp" source="~/../powershell-sdk-samples/SDK-2.0/csharp/StopProcessSample04/StopProcessSample04.cs" range="44-58":::
@@ -100,7 +100,7 @@ Note also that the alias "ProcessName" is given to this parameter.
 
 This input parameter allows the user to specify the identifiers of the processes to be stopped. Note
 that the `ParameterSetName` attribute keyword of the
-[System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
+[System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
 attribute specifies the `ProcessId` parameter set.
 
 ```csharp
@@ -141,7 +141,7 @@ Note also that the alias "ProcessId" is given to this parameter.
 
 This input parameter allows the user to specify an input object that contains information about the
 processes to be stopped. Note that the `ParameterSetName` attribute keyword of the
-[System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
+[System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
 attribute specifies the `InputObject` parameter set for this parameter.
 
 ```csharp
@@ -177,7 +177,7 @@ Note also that this parameter has no alias.
 
 Although there must be a unique parameter for each parameter set, parameters can belong to more than
 one parameter set. In these cases, give the shared parameter a
-[System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
+[System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
 attribute declaration for each set to which that the parameter belongs. If a parameter is in all
 parameter sets, you only have to declare the parameter attribute once and do not need to specify the
 parameter set name.
@@ -270,10 +270,10 @@ test their parameter sets to stop a process.
   parameter set to stop the process.
 
   ```
-  PS> stop-proc -Id 444
+  PS> Stop-Proc -Id 444
   Confirm
   Are you sure you want to perform this action?
-  Performing operation "stop-proc" on Target "notepad (444)".
+  Performing operation "Stop-Proc" on Target "notepad (444)".
   [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): Y
   ```
 
@@ -281,10 +281,10 @@ test their parameter sets to stop a process.
   stop processes on the Notepad object retrieved by the `Get-Process` command.
 
   ```
-  PS> get-process notepad | stop-proc
+  PS> Get-Process notepad | Stop-Proc
   Confirm
   Are you sure you want to perform this action?
-  Performing operation "stop-proc" on Target "notepad (444)".
+  Performing operation "Stop-Proc" on Target "notepad (444)".
   [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): N
   ```
 

--- a/reference/docs-conceptual/developer/cmdlet/adding-parameters-that-process-command-line-input.md
+++ b/reference/docs-conceptual/developer/cmdlet/adding-parameters-that-process-command-line-input.md
@@ -41,7 +41,7 @@ A cmdlet parameter enables the user to provide input to the cmdlet. In the follo
 `Get-Proc` and `Get-Member` are the names of pipelined cmdlets, and `MemberType` is a parameter
 for the `Get-Member` cmdlet. The parameter has the argument "property."
 
-**PS> get-proc ; `get-member` -membertype property**
+**PS> Get-Proc ; `Get-Member` -MemberType Property**
 
 To declare parameters for a cmdlet, you must first define the properties that represent the
 parameters. In the `Get-Proc` cmdlet, the only parameter is `Name`, which in this case represents
@@ -81,7 +81,7 @@ End Property
 ```
 
 To inform the Windows PowerShell runtime that this property is the `Name` parameter, a
-[System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
+[System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
 attribute is added to the property definition. The basic syntax for declaring this attribute is
 `[Parameter()]`.
 
@@ -142,7 +142,7 @@ not set in the attribute declaration.
 ## Supporting Parameter Validation
 
 The sample `Get-Proc` cmdlet adds an input validation attribute,
-[System.Management.Automation.Validatenotnulloremptyattribute](/dotnet/api/System.Management.Automation.ValidateNotNullOrEmptyAttribute),
+[System.Management.Automation.ValidateNotNullOrEmptyAttribute](/dotnet/api/System.Management.Automation.ValidateNotNullOrEmptyAttribute),
 to the `Name` parameter to enable validation that the input is neither `null` nor empty. This
 attribute is one of several validation attributes provided by Windows PowerShell. For examples of
 other validation attributes, see [Validating Parameter Input](./validating-parameter-input.md).
@@ -166,7 +166,7 @@ processes for each requested process name, or all for processes if no name is pr
 in
 [System.Management.Automation.Cmdlet.ProcessRecord](/dotnet/api/System.Management.Automation.Cmdlet.ProcessRecord),
 the call to
-[System.Management.Automation.Cmdlet.WriteObject%28System.Object%2CSystem.Boolean%29](/dotnet/api/system.management.automation.cmdlet.writeobject#System_Management_Automation_Cmdlet_WriteObject_System_Object_System_Boolean_)
+[System.Management.Automation.Cmdlet.WriteObject](/dotnet/api/System.Management.Automation.Cmdlet.WriteObject)
 is the output mechanism for sending output objects to the pipeline. The second parameter of this
 call, `enumerateCollection`, is set to `true` to inform the Windows PowerShell runtime to enumerate
 the output array of process objects and write one process at a time to the command line.
@@ -245,7 +245,7 @@ cmdlets from the command line, see
   which is named "IEXPLORE."
 
   ```powershell
-  get-proc -name iexplore
+  Get-Proc -Name iexplore
   ```
 
   The following output appears.
@@ -260,7 +260,7 @@ cmdlets from the command line, see
   "NOTEPAD," use the following command. If there are multiple processes, all of them are displayed.
 
   ```powershell
-  get-proc -name iexplore, outlook, notepad
+  Get-Proc -Name iexplore, outlook, notepad
   ```
 
   The following output appears.

--- a/reference/docs-conceptual/developer/cmdlet/adding-parameters-that-process-pipeline-input.md
+++ b/reference/docs-conceptual/developer/cmdlet/adding-parameters-that-process-pipeline-input.md
@@ -47,7 +47,7 @@ defines a property that represents the `Name` parameter as described in
 However, when a cmdlet needs to process pipeline input, it must have its parameters bound to input
 values by the Windows PowerShell runtime. To do this, you must add the `ValueFromPipeline` keyword
 or add the `ValueFromPipelineByProperty` keyword to the
-[System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
+[System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute)
 attribute declaration. Specify the `ValueFromPipeline` keyword if the cmdlet accesses the complete
 input object. Specify the `ValueFromPipelineByProperty` if the cmdlet accesses only a property of
 the object.
@@ -151,7 +151,7 @@ For the complete C# sample code, see [GetProcessSample03 Sample](./getprocesssam
 
 ## Defining Object Types and Formatting
 
-Windows PowerShell passes information between cmdlets using .Net objects. Consequently, a cmdlet may
+Windows PowerShell passes information between cmdlets using .NET objects. Consequently, a cmdlet may
 need to define its own type, or the cmdlet may need to extend an existing type provided by another
 cmdlet. For more information about defining new types or extending existing types, see
 [Extending Object Types and Formatting](/previous-versions//ms714665(v=vs.85)).
@@ -173,7 +173,7 @@ from the command line, see the
   through the pipeline.
 
   ```powershell
-  PS> type ProcessNames | get-proc
+  PS> type ProcessNames | Get-Proc
   ```
 
   The following output appears.
@@ -192,7 +192,7 @@ from the command line, see the
   PowerShell) as an upstream command to retrieve the "IEXPLORE" processes.
 
   ```powershell
-  PS> get-process iexplore | get-proc
+  PS> Get-Process iexplore | Get-Proc
   ```
 
   The following output appears.

--- a/reference/docs-conceptual/developer/cmdlet/adding-user-messages-to-your-cmdlet.md
+++ b/reference/docs-conceptual/developer/cmdlet/adding-user-messages-to-your-cmdlet.md
@@ -134,7 +134,7 @@ WriteObject(process);
 
 Windows PowerShell automatically routes any [System.Management.Automation.Cmdlet.WriteDebug](/dotnet/api/System.Management.Automation.Cmdlet.WriteDebug) calls to the tracing infrastructure and cmdlets. This allows the method calls to be traced to the hosting application, a file, or a debugger without your having to do any extra development work within the cmdlet. The following command-line entry implements a tracing operation.
 
-**PS> trace-expression stop-proc -file proc.log -command stop-proc notepad**
+**PS> Trace-Expression Stop-Proc -File proc.log -Command Stop-Proc notepad**
 
 ## Writing a Warning Message
 
@@ -163,7 +163,7 @@ The following code is an example of a progress message written by a cmdlet that 
 
 ```csharp
 int myId = 0;
-string myActivity = "Copy-item: Copying *.* to c:\abc";
+string myActivity = "Copy-item: Copying *.* to C:\abc";
 string myStatus = "Copying file bar.txt";
 ProgressRecord pr = new ProgressRecord(myId, myActivity, myStatus);
 WriteProgress(pr);
@@ -191,7 +191,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 - The following command-line entry uses Stop-Proc to stop the process named "NOTEPAD", provide verbose notifications, and print debug information.
 
     ```powershell
-    PS> stop-proc -Name notepad -Verbose -Debug
+    PS> Stop-Proc -Name notepad -Verbose -Debug
     ```
 
     The following output appears.
@@ -206,7 +206,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 
     Confirm
     Are you sure you want to perform this action?
-    Performing operation "stop-proc" on Target "notepad (5584)".
+    Performing operation "Stop-Proc" on Target "notepad (5584)".
     [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): Y
     VERBOSE: Stopped process "notepad", pid 5584.
     ```

--- a/reference/docs-conceptual/developer/cmdlet/alias-attribute-declaration.md
+++ b/reference/docs-conceptual/developer/cmdlet/alias-attribute-declaration.md
@@ -24,7 +24,7 @@ Required. Specifies a set of comma-separated alias names for the cmdlet paramete
 ## Remarks
 
 The **Alias** attribute is defined by the
-[System.Management.Automation.Aliasattribute](/dotnet/api/System.Management.Automation.AliasAttribute)
+[System.Management.Automation.AliasAttribute](/dotnet/api/System.Management.Automation.AliasAttribute)
 class.
 
 ### Cmdlet aliases

--- a/reference/docs-conceptual/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
+++ b/reference/docs-conceptual/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
@@ -159,7 +159,7 @@ to define actions that apply to data handling. The following table lists most of
 | [Expand](/dotnet/api/System.Management.Automation.VerbsData.Expand) (en)           | Restores the data of a resource that has been compressed to its original state. This verb is paired with `Compress`.                                                                                                                                                                            | Explode, Uncompress                              |
 | [Export](/dotnet/api/System.Management.Automation.VerbsData.Export) (ep)           | Encapsulates the primary input into a persistent data store, such as a file, or into an interchange format. This verb is paired with `Import`.                                                                                                                                                  | Extract, Backup                                  |
 | [Group](/dotnet/api/System.Management.Automation.VerbsData.Group) (gp)             | Arranges or associates one or more resources                                                                                                                                                                                                                                                    |                                                  |
-| [Import](/dotnet/api/System.Management.Automation.VerbsData.Import) (ip)           | Creates a resource from data that is stored in a persistent data store (such as a file) or in an interchange format. For example, the `Import-CSV` cmdlet imports data from a comma-separated value (CSV) file to objects that can be used by other cmdlets. This verb is paired with `Export`. | BulkLoad, Load                                   |
+| [Import](/dotnet/api/System.Management.Automation.VerbsData.Import) (ip)           | Creates a resource from data that is stored in a persistent data store (such as a file) or in an interchange format. For example, the `Import-Csv` cmdlet imports data from a comma-separated value (CSV) file to objects that can be used by other cmdlets. This verb is paired with `Export`. | BulkLoad, Load                                   |
 | [Initialize](/dotnet/api/System.Management.Automation.VerbsData.Initialize) (in)   | Prepares a resource for use, and sets it to a default state.                                                                                                                                                                                                                                    | Erase, Init, Renew, Rebuild, Reinitialize, Setup |
 | [Limit](/dotnet/api/System.Management.Automation.VerbsData.Limit) (l)              | Applies constraints to a resource.                                                                                                                                                                                                                                                              | Quota                                            |
 | [Merge](/dotnet/api/System.Management.Automation.VerbsData.Merge) (mg)             | Creates a single resource from multiple resources.                                                                                                                                                                                                                                              | Combine, Join                                    |
@@ -192,7 +192,7 @@ verbs.
 ## Lifecycle Verbs
 
 PowerShell uses the
-[System.Management.Automation.VerbsLifeCycle](/dotnet/api/System.Management.Automation.VerbsLifeCycle)
+[System.Management.Automation.VerbsLifecycle](/dotnet/api/System.Management.Automation.VerbsLifecycle)
 class to define actions that apply to the lifecycle of a resource. The following table lists most of
 the defined verbs.
 
@@ -253,7 +253,7 @@ common, communications, data, lifecycle, or security verb names verbs.
 - [System.Management.Automation.VerbsCommunications](/dotnet/api/System.Management.Automation.VerbsCommunications)
 - [System.Management.Automation.VerbsData](/dotnet/api/System.Management.Automation.VerbsData)
 - [System.Management.Automation.VerbsDiagnostic](/dotnet/api/System.Management.Automation.VerbsDiagnostic)
-- [System.Management.Automation.VerbsLifeCycle](/dotnet/api/System.Management.Automation.VerbsLifeCycle)
+- [System.Management.Automation.VerbsLifecycle](/dotnet/api/System.Management.Automation.VerbsLifecycle)
 - [System.Management.Automation.VerbsSecurity](/dotnet/api/System.Management.Automation.VerbsSecurity)
 - [System.Management.Automation.VerbsOther](/dotnet/api/System.Management.Automation.VerbsOther)
 - [Cmdlet Declaration](./cmdlet-class-declaration.md)

--- a/reference/docs-conceptual/developer/cmdlet/background-jobs.md
+++ b/reference/docs-conceptual/developer/cmdlet/background-jobs.md
@@ -26,7 +26,7 @@ To write a cmdlet that can be run as a background job, you must complete the fol
 
 - Define an `asJob` switch parameter so that the user can decide whether to run the cmdlet as a background job.
 
-- Create an object that derives from the [System.Management.Automation.Job](/dotnet/api/System.Management.Automation.Job) class. This object can be a custom job object or a job object provided by Windows PowerShell, such as a [System.Management.Automation.Pseventjob](/dotnet/api/System.Management.Automation.PSEventJob) object.
+- Create an object that derives from the [System.Management.Automation.Job](/dotnet/api/System.Management.Automation.Job) class. This object can be a custom job object or a job object provided by Windows PowerShell, such as a [System.Management.Automation.PSEventJob](/dotnet/api/System.Management.Automation.PSEventJob) object.
 
 - In a record processing method, add an `if` statement that detects whether the cmdlet should run as a background job.
 
@@ -43,16 +43,16 @@ The following APIs are provided by Windows PowerShell to manage background jobs.
 [System.Management.Automation.Job](/dotnet/api/System.Management.Automation.Job)
 Derives custom job objects. This is an abstract class.
 
-[System.Management.Automation.Jobrepository](/dotnet/api/System.Management.Automation.JobRepository)
+[System.Management.Automation.JobRepository](/dotnet/api/System.Management.Automation.JobRepository)
 Manages and provides information about the current active background jobs.
 
-[System.Management.Automation.Jobstate](/dotnet/api/System.Management.Automation.JobState)
+[System.Management.Automation.JobState](/dotnet/api/System.Management.Automation.JobState)
 Defines the state of the background job. States include Started, Running, and Stopped.
 
-[System.Management.Automation.Jobstateinfo](/dotnet/api/System.Management.Automation.JobStateInfo)
+[System.Management.Automation.JobStateInfo](/dotnet/api/System.Management.Automation.JobStateInfo)
 Provides information about the state of a background job and, if the last state change was caused by an error, the reason the job entered its current state.
 
-[System.Management.Automation.Jobstateeventargs](/dotnet/api/System.Management.Automation.JobStateEventArgs)
+[System.Management.Automation.JobStateEventArgs](/dotnet/api/System.Management.Automation.JobStateEventArgs)
 Provides the arguments for an event that is raised when a background job changes state.
 
 ## Windows PowerShell Job Cmdlets

--- a/reference/docs-conceptual/developer/cmdlet/cmdlet-attribute-declaration.md
+++ b/reference/docs-conceptual/developer/cmdlet/cmdlet-attribute-declaration.md
@@ -26,7 +26,7 @@ Required. Specifies the cmdlet noun. This noun specifies the resource that the c
 `SupportsShouldProcess` ([System.Boolean](/dotnet/api/System.Boolean))
 Optional named parameter. `True` indicates that the cmdlet supports calls to the [System.Management.Automation.Cmdlet.ShouldProcess](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess) method, which provides the cmdlet with a way to prompt the user before an action that changes the system is performed. `False`, the default value, indicates that the cmdlet does not support calls to the [System.Management.Automation.Cmdlet.ShouldProcess](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess) method. For more information about confirmation requests, see [Requesting Confirmation](./requesting-confirmation-from-cmdlets.md).
 
-`ConfirmImpact` ([System.Management.Automation.Confirmimpact](/dotnet/api/System.Management.Automation.ConfirmImpact))
+`ConfirmImpact` ([System.Management.Automation.ConfirmImpact](/dotnet/api/System.Management.Automation.ConfirmImpact))
 Optional named parameter. Specifies when the action of the cmdlet should be confirmed by a call to the [System.Management.Automation.Cmdlet.ShouldProcess](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess) method. [System.Management.Automation.Cmdlet.ShouldProcess](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess) will only be called when the ConfirmImpact value of the cmdlet (by default, Medium) is equal to or greater than the value of the `$ConfirmPreference` variable. This parameter should be specified only when the `SupportsShouldProcess` parameter is specified.
 
 `DefaultParameterSetName` ([System.String](/dotnet/api/System.String))

--- a/reference/docs-conceptual/developer/cmdlet/cmdlet-dynamic-parameters.md
+++ b/reference/docs-conceptual/developer/cmdlet/cmdlet-dynamic-parameters.md
@@ -28,7 +28,7 @@ The following examples show how the **CodeSigningCert** parameter is added at ru
 In this example, the PowerShell runtime has added the parameter and the cmdlet is successful.
 
 ```powershell
-Get-Item -Path cert:\CurrentUser -CodeSigningCert
+Get-Item -Path Cert:\CurrentUser -CodeSigningCert
 ```
 
 ```Output
@@ -44,9 +44,9 @@ Get-Item -Path C:\ -CodeSigningCert
 ```
 
 ```Output
-Get-Item : A parameter cannot be found that matches parameter name 'codesigningcert'.
+Get-Item : A parameter cannot be found that matches parameter name 'CodeSigningCert'.
 At line:1 char:37
-+  get-item -path C:\ -codesigningcert <<<<
++  Get-Item -Path C:\ -CodeSigningCert <<<<
 --------
     CategoryInfo          : InvalidArgument: (:) [Get-Item], ParameterBindingException
     FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.PowerShell.Commands.GetItemCommand

--- a/reference/docs-conceptual/developer/cmdlet/cmdlet-output.md
+++ b/reference/docs-conceptual/developer/cmdlet/cmdlet-output.md
@@ -17,10 +17,10 @@ Describes the types and output that cmdlets can generate and the methods that cm
 Discusses cmdlet error reporting, a subset of cmdlet output.
 
 [Extending Output Objects](./extending-output-objects.md)
-Discusses how to use the types files (.ps1xml) to extend the .NET Framework objects that are returned by cmdlets, functions, and scripts.
+Discusses how to use the types files (`.ps1xml`) to extend the .NET Framework objects that are returned by cmdlets, functions, and scripts.
 
 [PowerShell Formatting Files](../format/powershell-formatting-files.md)
-Describes the formatting files (.format.ps1xml) files that define the default display for a specific set of .NET Framework objects in Windows PowerShell.
+Describes the formatting files (`.format.ps1xml`) files that define the default display for a specific set of .NET Framework objects in Windows PowerShell.
 
 [Custom Formatting Files](./custom-formatting-files.md)
 Describes how to create your own custom formatting files to overwrite the default display formats or to define the display of objects returned by your own commands.

--- a/reference/docs-conceptual/developer/cmdlet/cmdlet-overview.md
+++ b/reference/docs-conceptual/developer/cmdlet/cmdlet-overview.md
@@ -34,7 +34,7 @@ specialized cmdlet base classes. The derived class must:
 You can load the assembly that contains the class directly by using the
 [Import-Module](/powershell/module/microsoft.powershell.core/import-module) cmdlet, or you can
 create a host application that loads the assembly by using the
-[System.Management.Automation.Runspaces.Initialsessionstate](/dotnet/api/System.Management.Automation.Runspaces.InitialSessionState)
+[System.Management.Automation.Runspaces.InitialSessionState](/dotnet/api/System.Management.Automation.Runspaces.InitialSessionState)
 API. Both methods provide programmatic and command-line access to the functionality of the cmdlet.
 
 ## Cmdlet Terms

--- a/reference/docs-conceptual/developer/cmdlet/cmdlet-sets.md
+++ b/reference/docs-conceptual/developer/cmdlet/cmdlet-sets.md
@@ -18,7 +18,7 @@ Keep the following things in mind when implementing a base class.
 
 - Declare the [System.Management.Automation.CmdletAttribute](/dotnet/api/System.Management.Automation.CmdletAttribute) attribute on all cmdlet classes, but do not declare it on the base class.
 
-- Implement a [System.Management.Automation.PSSnapIn](/dotnet/api/System.Management.Automation.PSSnapIn) or [System.Management.Automation.Custompssnapin](/dotnet/api/System.Management.Automation.CustomPSSnapIn) class whose name and description reflects the set of cmdlets.
+- Implement a [System.Management.Automation.PSSnapIn](/dotnet/api/System.Management.Automation.PSSnapIn) or [System.Management.Automation.CustomPSSnapIn](/dotnet/api/System.Management.Automation.CustomPSSnapIn) class whose name and description reflects the set of cmdlets.
 
 ## Example
 

--- a/reference/docs-conceptual/developer/cmdlet/confirmation-messages.md
+++ b/reference/docs-conceptual/developer/cmdlet/confirmation-messages.md
@@ -19,7 +19,7 @@ methods that are called.
 ## Specifying the Resource
 
 You can specify the resource that is about to be changed by calling the
-[System.Management.Automation.Cmdlet.Shouldprocess%2A?Displayproperty=Fullname](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess)
+[System.Management.Automation.Cmdlet.ShouldProcess](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess)
 method. In this case, you supply the resource by using the `target` parameter of the method, and the
 operation is added by Windows PowerShell. In the following message, the text "MyResource" is the
 resource acted on and the operation is the name of the command that makes the call.
@@ -51,7 +51,7 @@ Continue with this operation?
 
 You can specify the resource that is about to be changed and the operation that the command is about
 to perform by calling the
-[System.Management.Automation.Cmdlet.Shouldprocess%2A?Displayproperty=Fullname](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess)
+[System.Management.Automation.Cmdlet.ShouldProcess](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess)
 method. In this case, you supply the resource by using the `target` parameter and the operation by
 using the `target` parameter. In the following message, the text "MyResource" is the resource acted
 on and "MyAction" is the operation to be performed.

--- a/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-that-modifies-the-system.md
+++ b/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-that-modifies-the-system.md
@@ -32,7 +32,7 @@ system outside Windows PowerShell. For example, stopping a process, enabling or 
 account, or adding a row to a database table are all changes to the system that should be confirmed.
 In contrast, operations that read data or establish transient connections do not change the system
 and generally do not require confirmation. Confirmation is also not needed for actions whose effect
-is limited to inside the Windows PowerShell runtime, such as `set-variable`. Cmdlets that might or
+is limited to inside the Windows PowerShell runtime, such as `Set-Variable`. Cmdlets that might or
 might not make a persistent change should declare `SupportsShouldProcess` and call
 [System.Management.Automation.Cmdlet.ShouldProcess](/dotnet/api/System.Management.Automation.Cmdlet.ShouldProcess)
 only if they are about to make a persistent change.
@@ -54,7 +54,7 @@ The first step in cmdlet creation is always naming the cmdlet and declaring the 
 implements the cmdlet. Because you are writing a cmdlet to change the system, it should be named
 accordingly. This cmdlet stops system processes, so the verb name chosen here is "Stop", defined by
 the
-[System.Management.Automation.Verbslifecycle](/dotnet/api/System.Management.Automation.VerbsLifeCycle)
+[System.Management.Automation.VerbsLifecycle](/dotnet/api/System.Management.Automation.VerbsLifecycle)
 class, with the noun "Proc" to indicate that the cmdlet stops processes. For more information about
 approved cmdlet verbs, see
 [Cmdlet Verb Names](./approved-verbs-for-windows-powershell-commands.md).
@@ -90,7 +90,7 @@ if `ConfirmImpact` is set to
 
 Similarly, some operations are unlikely to be destructive, although they do in theory modify the
 running state of a system outside Windows PowerShell. Such cmdlets can set `ConfirmImpact` to
-[System.Management.Automation.Confirmimpact.Low](/dotnet/api/system.management.automation.confirmimpact).
+[System.Management.Automation.ConfirmImpact.Low](/dotnet/api/system.management.automation.confirmimpact).
 This will bypass confirmation requests where the user has asked to confirm only medium-impact and
 high-impact operations.
 
@@ -361,7 +361,7 @@ For the complete C# sample code, see [StopProcessSample01 Sample](./stopprocesss
 
 ## Defining Object Types and Formatting
 
-Windows PowerShell passes information between cmdlets using .Net objects. Consequently, a cmdlet may
+Windows PowerShell passes information between cmdlets using .NET objects. Consequently, a cmdlet may
 need to define its own type, or the cmdlet may need to extend an existing type provided by another
 cmdlet. For more information about defining new types or extending existing types, see
 [Extending Object Types and Formatting](/previous-versions//ms714665(v=vs.85)).
@@ -383,13 +383,13 @@ using cmdlets from the command line, see the
   the cmdlet specifies the `Name` parameter as mandatory, the cmdlet queries for the parameter.
 
     ```powershell
-    PS> stop-proc
+    PS> Stop-Proc
     ```
 
     The following output appears.
 
     ```
-    Cmdlet stop-proc at command pipeline position 1
+    Cmdlet Stop-Proc at command pipeline position 1
     Supply values for the following parameters:
     Name[0]:
     ```
@@ -398,7 +398,7 @@ using cmdlets from the command line, see the
   action.
 
     ```powershell
-    PS> stop-proc -Name notepad
+    PS> Stop-Proc -Name notepad
     ```
 
     The following output appears.
@@ -406,7 +406,7 @@ using cmdlets from the command line, see the
     ```
     Confirm
     Are you sure you want to perform this action?
-    Performing operation "stop-proc" on Target "notepad (4996)".
+    Performing operation "Stop-Proc" on Target "notepad (4996)".
     [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): Y
     ```
 
@@ -414,7 +414,7 @@ using cmdlets from the command line, see the
   about performing this action because it will cause the operating system to reboot.
 
     ```powershell
-    PS> stop-proc -Name Winlogon
+    PS> Stop-Proc -Name Winlogon
     ```
 
     The following output appears.
@@ -422,7 +422,7 @@ using cmdlets from the command line, see the
     ```Output
     Confirm
     Are you sure you want to perform this action?
-    Performing operation "stop-proc" on Target "winlogon (656)".
+    Performing operation "Stop-Proc" on Target "winlogon (656)".
     [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): Y
     Warning!
     The process " winlogon " is a critical process and should not be stopped. Are you sure you wish to stop the process?
@@ -433,7 +433,7 @@ using cmdlets from the command line, see the
   entry uses the `Force` parameter to override the warning.
 
     ```powershell
-    PS> stop-proc -Name winlogon -Force
+    PS> Stop-Proc -Name winlogon -Force
     ```
 
     The following output appears.
@@ -441,7 +441,7 @@ using cmdlets from the command line, see the
     ```Output
     Confirm
     Are you sure you want to perform this action?
-    Performing operation "stop-proc" on Target "winlogon (656)".
+    Performing operation "Stop-Proc" on Target "winlogon (656)".
     [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): N
     ```
 

--- a/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-to-access-a-data-store.md
+++ b/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-to-access-a-data-store.md
@@ -10,13 +10,13 @@ This section describes how to create a cmdlet that accesses stored data by way o
 
 The Select-Str cmdlet described here can locate and select strings in a file or object. The patterns used to identify the string can be specified explicitly through the `Path` parameter of the cmdlet or implicitly through the `Script` parameter.
 
-The cmdlet is designed to use any Windows PowerShell provider that derives from [System.Management.Automation.Provider.Icontentcmdletprovider](/dotnet/api/System.Management.Automation.Provider.IContentCmdletProvider). For example, the cmdlet can specify the FileSystem provider or the Variable provider that is provided by Windows PowerShell. For more information aboutWindows PowerShell providers, see [Designing Your Windows PowerShell provider](../prog-guide/designing-your-windows-powershell-provider.md).
+The cmdlet is designed to use any Windows PowerShell provider that derives from [System.Management.Automation.Provider.IContentCmdletProvider](/dotnet/api/System.Management.Automation.Provider.IContentCmdletProvider). For example, the cmdlet can specify the FileSystem provider or the Variable provider that is provided by Windows PowerShell. For more information aboutWindows PowerShell providers, see [Designing Your Windows PowerShell provider](../prog-guide/designing-your-windows-powershell-provider.md).
 
 ## Defining the Cmdlet Class
 
-The first step in cmdlet creation is always naming the cmdlet and declaring the .NET class that implements the cmdlet. This cmdlet detects certain strings, so the verb name chosen here is "Select", defined by the [System.Management.Automation.Verbscommon](/dotnet/api/System.Management.Automation.VerbsCommon) class. The noun name "Str" is used because the cmdlet acts upon strings. In the declaration below, note that the cmdlet verb and noun name are reflected in the name of the cmdlet class. For more information about approved cmdlet verbs, see [Cmdlet Verb Names](./approved-verbs-for-windows-powershell-commands.md).
+The first step in cmdlet creation is always naming the cmdlet and declaring the .NET class that implements the cmdlet. This cmdlet detects certain strings, so the verb name chosen here is "Select", defined by the [System.Management.Automation.VerbsCommon](/dotnet/api/System.Management.Automation.VerbsCommon) class. The noun name "Str" is used because the cmdlet acts upon strings. In the declaration below, note that the cmdlet verb and noun name are reflected in the name of the cmdlet class. For more information about approved cmdlet verbs, see [Cmdlet Verb Names](./approved-verbs-for-windows-powershell-commands.md).
 
-The .NET class for this cmdlet must derive from the [System.Management.Automation.PSCmdlet](/dotnet/api/System.Management.Automation.PSCmdlet) base class, because it provides the support needed by the Windows PowerShell runtime to expose the Windows PowerShell provider infrastructure. Note that this cmdlet also makes use of the .NET Framework regular expressions classes, such as [System.Text.Regularexpressions.Regex](/dotnet/api/System.Text.RegularExpressions.Regex).
+The .NET class for this cmdlet must derive from the [System.Management.Automation.PSCmdlet](/dotnet/api/System.Management.Automation.PSCmdlet) base class, because it provides the support needed by the Windows PowerShell runtime to expose the Windows PowerShell provider infrastructure. Note that this cmdlet also makes use of the .NET Framework regular expressions classes, such as [System.Text.RegularExpressions.Regex](/dotnet/api/System.Text.RegularExpressions.Regex).
 
 The following code is the class definition for this Select-Str cmdlet.
 
@@ -59,9 +59,9 @@ private string[] paths;
 
 Note that this parameter belongs to two different parameter sets and that it has an alias.
 
-Two [System.Management.Automation.Parameterattribute](/dotnet/api/System.Management.Automation.ParameterAttribute) attributes declare that the `Path` parameter belongs to the `ScriptParameterSet` and the `PatternParameterSet`. For more information about parameter sets, see [Adding Parameter Sets to a Cmdlet](./adding-parameter-sets-to-a-cmdlet.md).
+Two [System.Management.Automation.ParameterAttribute](/dotnet/api/System.Management.Automation.ParameterAttribute) attributes declare that the `Path` parameter belongs to the `ScriptParameterSet` and the `PatternParameterSet`. For more information about parameter sets, see [Adding Parameter Sets to a Cmdlet](./adding-parameter-sets-to-a-cmdlet.md).
 
-The [System.Management.Automation.Aliasattribute](/dotnet/api/System.Management.Automation.AliasAttribute) attribute declares a `PSPath` alias for the `Path` parameter. Declaring this alias is strongly recommended for consistency with other cmdlets that access Windows PowerShell providers. For more information aboutWindows PowerShell paths, see "PowerShell Path Concepts" in [How Windows PowerShell Works](/previous-versions//ms714658(v=vs.85)).
+The [System.Management.Automation.AliasAttribute](/dotnet/api/System.Management.Automation.AliasAttribute) attribute declares a `PSPath` alias for the `Path` parameter. Declaring this alias is strongly recommended for consistency with other cmdlets that access Windows PowerShell providers. For more information aboutWindows PowerShell paths, see "PowerShell Path Concepts" in [How Windows PowerShell Works](/previous-versions//ms714658(v=vs.85)).
 
 ### Declaring the Pattern Parameter
 
@@ -362,9 +362,9 @@ protected override void ProcessRecord()
 
 ## Accessing Content
 
-Your cmdlet must open the provider indicated by the Windows PowerShell path so that it can access the data. The [System.Management.Automation.Sessionstate](/dotnet/api/System.Management.Automation.SessionState) object for the runspace is used for access to the provider, while the [System.Management.Automation.PSCmdlet.Invokeprovider*](/dotnet/api/System.Management.Automation.PSCmdlet.InvokeProvider) property of the cmdlet is used to open the provider. Access to content is provided by retrieval of the [System.Management.Automation.Providerintrinsics](/dotnet/api/System.Management.Automation.ProviderIntrinsics) object for the provider opened.
+Your cmdlet must open the provider indicated by the Windows PowerShell path so that it can access the data. The [System.Management.Automation.SessionState](/dotnet/api/System.Management.Automation.SessionState) object for the runspace is used for access to the provider, while the [System.Management.Automation.PSCmdlet.InvokeProvider*](/dotnet/api/System.Management.Automation.PSCmdlet.InvokeProvider) property of the cmdlet is used to open the provider. Access to content is provided by retrieval of the [System.Management.Automation.ProviderIntrinsics](/dotnet/api/System.Management.Automation.ProviderIntrinsics) object for the provider opened.
 
-This sample Select-Str cmdlet uses the [System.Management.Automation.Providerintrinsics.Content*](/dotnet/api/System.Management.Automation.ProviderIntrinsics.Content) property to expose the content to scan. It can then call the [System.Management.Automation.Contentcmdletproviderintrinsics.Getreader*](/dotnet/api/System.Management.Automation.ContentCmdletProviderIntrinsics.GetReader) method, passing the required Windows PowerShell path.
+This sample Select-Str cmdlet uses the [System.Management.Automation.ProviderIntrinsics.Content*](/dotnet/api/System.Management.Automation.ProviderIntrinsics.Content) property to expose the content to scan. It can then call the [System.Management.Automation.ContentCmdletProviderIntrinsics.GetReader*](/dotnet/api/System.Management.Automation.ContentCmdletProviderIntrinsics.GetReader) method, passing the required Windows PowerShell path.
 
 ## Code Sample
 
@@ -1088,7 +1088,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 1. Start Windows PowerShell, and search the Notes file for occurrences of lines with the expression ".NET". Note that the quotation marks around the name of the path are required only if the path consists of more than one word.
 
     ```powershell
-    select-str -Path "notes" -Pattern ".NET" -SimpleMatch=$false
+    Select-Str -Path "notes" -Pattern ".NET" -SimpleMatch=$false
     ```
 
     The following output appears.
@@ -1109,7 +1109,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 2. Search the Notes file for occurrences of lines with the word "over", followed by any other text. The `SimpleMatch` parameter is using the default value of `false`. The search is case-insensitive because the `CaseSensitive` parameter is set to `false`.
 
     ```powershell
-    select-str -Path notes -Pattern "over*" -SimpleMatch -CaseSensitive:$false
+    Select-Str -Path notes -Pattern "over*" -SimpleMatch -CaseSensitive:$false
     ```
 
     The following output appears.
@@ -1130,7 +1130,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 3. Search the Notes file using a regular expression as the pattern. The cmdlet searches for alphabetical characters and blank spaces enclosed in parentheses.
 
     ```powershell
-    select-str -Path notes -Pattern "\([A-Za-z:blank:]" -SimpleMatch:$false
+    Select-Str -Path notes -Pattern "\([A-Za-z:blank:]" -SimpleMatch:$false
     ```
 
     The following output appears.
@@ -1151,7 +1151,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 4. Perform a case-sensitive search of the Notes file for occurrences of the word "Parameter".
 
     ```powershell
-    select-str -Path notes -Pattern Parameter -CaseSensitive
+    Select-Str -Path notes -Pattern Parameter -CaseSensitive
     ```
 
     The following output appears.
@@ -1169,10 +1169,10 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
     Pattern      : Parameter
     ```
 
-5. Search the variable provider shipped with Windows PowerShell for variables that have numerical values from 0 through 9.
+5. Search the Variable provider shipped with Windows PowerShell for variables that have numerical values from 0 through 9.
 
     ```powershell
-    select-str -Path * -Pattern "[0-9]"
+    Select-Str -Path * -Pattern "[0-9]"
     ```
 
     The following output appears.
@@ -1185,10 +1185,10 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
     Pattern      : [0-9]
     ```
 
-6. Use a script block to search the file SelectStrCommandSample.cs for the string "Pos". The **cmatch** function for the script performs a case-insensitive pattern match.
+6. Use a script block to search the file SelectStrCommandSample.cs for the string "Pos". The `-cmatch` operator performs a case-insensitive pattern match.
 
     ```powershell
-    select-str -Path "SelectStrCommandSample.cs" -Script { if ($args[0] -cmatch "Pos"){ return $true } return $false }
+    Select-Str -Path "SelectStrCommandSample.cs" -Script { if ($args[0] -cmatch "Pos"){ return $true } return $false }
     ```
 
     The following output appears.

--- a/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-without-parameters.md
+++ b/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-without-parameters.md
@@ -13,7 +13,7 @@ This section describes how to create a cmdlet that retrieves information from th
 
 ## Naming the Cmdlet
 
-A cmdlet name consists of a verb that indicates the action the cmdlet takes and a noun that indicates the items that the cmdlet acts upon. Because this sample Get-Proc cmdlet retrieves process objects, it uses the verb "Get", defined by the [System.Management.Automation.Verbscommon](/dotnet/api/System.Management.Automation.VerbsCommon) enumeration, and the noun "Proc" to indicate that the cmdlet works on process items.
+A cmdlet name consists of a verb that indicates the action the cmdlet takes and a noun that indicates the items that the cmdlet acts upon. Because this sample Get-Proc cmdlet retrieves process objects, it uses the verb "Get", defined by the [System.Management.Automation.VerbsCommon](/dotnet/api/System.Management.Automation.VerbsCommon) enumeration, and the noun "Proc" to indicate that the cmdlet works on process items.
 
 When naming cmdlets, do not use any of the following characters: # , () {} [] & - /\ $ ; : " '<> &#124; ? @ ` .
 
@@ -136,7 +136,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 1. Start Windows PowerShell, and get the current processes running on the computer.
 
     ```powershell
-    get-proc
+    Get-Proc
     ```
 
     The following output appears.
@@ -154,13 +154,13 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 2. Assign a variable to the cmdlet results for easier manipulation.
 
     ```powershell
-    $p=get-proc
+    $p=Get-Proc
     ```
 
 3. Get the number of processes.
 
     ```powershell
-    $p.length
+    $p.Length
     ```
 
     The following output appears.
@@ -186,7 +186,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 5. Get the start time of this process.
 
     ```powershell
-    $p[6].starttime
+    $p[6].StartTime
     ```
 
     The following output appears.
@@ -196,7 +196,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
     ```
 
     ```powershell
-    $p[6].starttime.dayofyear
+    $p[6].StartTime.DayOfYear
     ```
 
     ```output
@@ -224,7 +224,7 @@ When your cmdlet has been registered with Windows PowerShell, you can test it by
 7. Use the `Get-Member` cmdlet to list the properties available for each process.
 
     ```powershell
-    $p | Get-Member -MemberType property
+    $p | Get-Member -MemberType Property
     ```
 
     ```output

--- a/reference/docs-conceptual/developer/cmdlet/credential-attribute-declaration.md
+++ b/reference/docs-conceptual/developer/cmdlet/credential-attribute-declaration.md
@@ -22,7 +22,7 @@ The Credential attribute is an optional attribute that can be used with credenti
 
 - This attribute is used with the Parameter attribute. For more information about that attribute, see [Parameter Attribute Declaration](./parameter-attribute-declaration.md).
 
-- The credential attribute is defined by the [System.Management.Automation.Credentialattribute](/dotnet/api/System.Management.Automation.CredentialAttribute) class.
+- The credential attribute is defined by the [System.Management.Automation.CredentialAttribute](/dotnet/api/System.Management.Automation.CredentialAttribute) class.
 
 ## See Also
 

--- a/reference/docs-conceptual/developer/cmdlet/custom-formatting-files.md
+++ b/reference/docs-conceptual/developer/cmdlet/custom-formatting-files.md
@@ -6,7 +6,7 @@ title: Custom Formatting Files
 ---
 # Custom Formatting Files
 
-The display format for the objects returned by cmdlets, functions, and scripts are defined using formatting files (format.ps1xml files). Several of these files are provided by Windows PowerShell to define the default display format for those objects returned by Windows PowerShell cmdlets. However, you can also create your own custom formatting files to overwrite the default display formats or to define the display of objects returned by your own commands.
+The display format for the objects returned by cmdlets, functions, and scripts are defined using formatting files (`format.ps1xml` files). Several of these files are provided by Windows PowerShell to define the default display format for those objects returned by Windows PowerShell cmdlets. However, you can also create your own custom formatting files to overwrite the default display formats or to define the display of objects returned by your own commands.
 
 Windows PowerShell uses the data in these formatting files to determine what is displayed and how the data is formatted. The displayed data can include the properties of an object or the value of a script block.  Script blocks are used if you want to display some value that is not available directly from the properties of an object. For example, you may want to add the value of two properties of an object and display the sum as a separate piece of data. When you write your own formatting file, you will need to define *views* for the objects that you want to display. You can define a single view for each object, you can define a single view for multiple objects, or you can define multiple views for the same object. There is no limit to the number of views that you can define.
 

--- a/reference/docs-conceptual/developer/cmdlet/defining-default-member-sets-for-objects.md
+++ b/reference/docs-conceptual/developer/cmdlet/defining-default-member-sets-for-objects.md
@@ -35,7 +35,7 @@ In the following example, the PSStandardMembers member set defines the DefaultDi
 The following output shows the default properties returned by the [Format-List](/powershell/module/Microsoft.PowerShell.Utility/Format-List) cmdlet. Only the `Id`, `Handles`, `CPU`, and `Name` properties are returned for each process object.
 
 ```powershell
-Get-Process | format-list
+Get-Process | Format-List
 ```
 
 ```output

--- a/reference/docs-conceptual/developer/cmdlet/displaying-error-information.md
+++ b/reference/docs-conceptual/developer/cmdlet/displaying-error-information.md
@@ -11,7 +11,7 @@ This topic discusses the ways in which users can display error information.
 When your cmdlet encounters an error, the presentation of the error information will, by default, resemble the following error output.
 
 ```powershell
-$ stop-service lanmanworkstation
+$ Stop-Service lanmanworkstation
 You do not have sufficient permissions to stop the service Workstation.
 ```
 
@@ -19,8 +19,8 @@ However, users can view errors by category by setting the `$ErrorView` variable 
 
 ```powershell
 $ $ErrorView = "CategoryView"
-$ stop-service lanmanworkstation
-CloseError: (System.ServiceProcess.ServiceController:ServiceController) [stop-service], ServiceCommandException
+$ Stop-Service lanmanworkstation
+CloseError: (System.ServiceProcess.ServiceController:ServiceController) [Stop-Service], ServiceCommandException
 ```
 
 For more information about error categories, see [Windows PowerShell Error Records](./windows-powershell-error-records.md).

--- a/reference/docs-conceptual/developer/cmdlet/error-reporting-concepts.md
+++ b/reference/docs-conceptual/developer/cmdlet/error-reporting-concepts.md
@@ -8,7 +8,7 @@ title: Error Reporting Concepts
 
 Windows PowerShell provides two mechanisms for reporting errors: one mechanism for *terminating errors* and another mechanism for *non-terminating errors*. It is important for your cmdlet to report errors correctly so that the host application that is running your cmdlets can react in an appropriate manner.
 
-Your cmdlet should call the [System.Management.Automation.Cmdlet.Throwterminatingerror*](/dotnet/api/System.Management.Automation.Cmdlet.ThrowTerminatingError) method when an error occurs that does not or should not allow the cmdlet to continue to process its input objects. Your cmdlet should call the [System.Management.Automation.Cmdlet.WriteError](/dotnet/api/System.Management.Automation.Cmdlet.WriteError) method to report non-terminating errors when the cmdlet can continue processing the input objects. Both methods provide an error record that the host application can use to investigate the cause of the error.
+Your cmdlet should call the [System.Management.Automation.Cmdlet.ThrowTerminatingError*](/dotnet/api/System.Management.Automation.Cmdlet.ThrowTerminatingError) method when an error occurs that does not or should not allow the cmdlet to continue to process its input objects. Your cmdlet should call the [System.Management.Automation.Cmdlet.WriteError](/dotnet/api/System.Management.Automation.Cmdlet.WriteError) method to report non-terminating errors when the cmdlet can continue processing the input objects. Both methods provide an error record that the host application can use to investigate the cause of the error.
 
 Use the following guidelines to determine whether an error is a terminating or non-terminating error.
 
@@ -24,7 +24,7 @@ Use the following guidelines to determine whether an error is a terminating or n
 
 ## See Also
 
-[System.Management.Automation.Cmdlet.Throwterminatingerror*](/dotnet/api/System.Management.Automation.Cmdlet.ThrowTerminatingError)
+[System.Management.Automation.Cmdlet.ThrowTerminatingError*](/dotnet/api/System.Management.Automation.Cmdlet.ThrowTerminatingError)
 
 [System.Management.Automation.Cmdlet.WriteError](/dotnet/api/System.Management.Automation.Cmdlet.WriteError)
 

--- a/reference/docs-conceptual/developer/cmdlet/events01-sample.md
+++ b/reference/docs-conceptual/developer/cmdlet/events01-sample.md
@@ -43,7 +43,7 @@ derives from the [Microsoft.PowerShell.Commands.ObjectEventRegistrationBase][1] 
    file is created under the TEMP directory.
 
     ```powershell
-    Register-FileSystemEvent $env:temp Created -filter "*.txt" -action { Write-Host "A file was created in the TEMP directory" }
+    Register-FileSystemEvent $Env:TEMP Created -Filter "*.txt" -Action { Write-Host "A file was created in the TEMP directory" }
     ```
 
 1. Create a file under the TEMP directory and note that the action is executed (the message is
@@ -59,7 +59,7 @@ Id              Name            State      HasMoreData     Location             
 ```
 
 ```powershell
-Set-Content $env:temp\test.txt "This is a test file"
+Set-Content $Env:TEMP\test.txt "This is a test file"
 ```
 
 ```output

--- a/reference/docs-conceptual/developer/cmdlet/extending-output-objects.md
+++ b/reference/docs-conceptual/developer/cmdlet/extending-output-objects.md
@@ -6,7 +6,7 @@ title: Extending Output Objects
 ---
 # Extending Output Objects
 
-You can extend the .NET Framework objects that are returned by cmdlets, functions, and scripts by using types files (.ps1xml). Types files are XML-based files that let you add properties and methods to existing objects. For example, Windows PowerShell provides the Types.ps1xml file, which adds elements to several existing .NET Framework objects. The Types.ps1xml file is located in the Windows PowerShell installation directory (`$PSHOME`). You can create your own types file to further extend those objects or to extend other objects. When you extend an object by using a types file, any instance of the object is extended with the new elements.
+You can extend the .NET Framework objects that are returned by cmdlets, functions, and scripts by using types files (`.ps1xml`). Types files are XML-based files that let you add properties and methods to existing objects. For example, Windows PowerShell provides the Types.ps1xml file, which adds elements to several existing .NET Framework objects. The `Types.ps1xml` file is located in the Windows PowerShell installation directory (`$PSHOME`). You can create your own types file to further extend those objects or to extend other objects. When you extend an object by using a types file, any instance of the object is extended with the new elements.
 
 ## Extending the System.Array Object
 
@@ -66,7 +66,7 @@ PS> (1, 2, 3, 4).Length
 
 ## Custom Types Files
 
-To create a custom types file, start by copying an existing types file. The new file can have any name, but it must have a .ps1xml file name extension. When you copy the file, you can place the new file in any directory that is accessible to Windows PowerShell, but it is useful to place the files in the Windows PowerShell installation directory (`$PSHOME`) or in a subdirectory of the installation directory.
+To create a custom types file, start by copying an existing types file. The new file can have any name, but it must have a `.ps1xml` file name extension. When you copy the file, you can place the new file in any directory that is accessible to Windows PowerShell, but it is useful to place the files in the Windows PowerShell installation directory (`$PSHOME`) or in a subdirectory of the installation directory.
 
 To add your own extended types to the file, add a types element for each object that you want to extend. The following topics provide examples.
 

--- a/reference/docs-conceptual/developer/cmdlet/extending-properties-for-objects.md
+++ b/reference/docs-conceptual/developer/cmdlet/extending-properties-for-objects.md
@@ -132,7 +132,7 @@ set names include **DefaultDisplayProperty**, **DefaultDisplayPropertySet**, and
 member set are ignored.
 
 In the following example, the **DefaultDisplayPropertySet** property set is added to the
-**PSStandardMembers** member set of the [System.Serviceprocess.Servicecontroller](/dotnet/api/System.ServiceProcess.ServiceController)
+**PSStandardMembers** member set of the [System.ServiceProcess.ServiceController](/dotnet/api/System.ServiceProcess.ServiceController)
 type. The [PropertySet](/dotnet/api/system.management.automation.pspropertyset) element defines the
 group of properties. The [Name](/dotnet/api/system.management.automation.psmemberinfo.name) element
 specifies the name of the property set. And, the

--- a/reference/docs-conceptual/developer/cmdlet/getprocesssample01-sample.md
+++ b/reference/docs-conceptual/developer/cmdlet/getprocesssample01-sample.md
@@ -36,9 +36,9 @@ cmdlet is a simplified version of the `Get-Process` cmdlet that is provided by W
 
    `Add-PSSnapin GetProcPSSnapIn01`
 
-1. Enter the following command to run the cmdlet. `get-proc`
+1. Enter the following command to run the cmdlet. `Get-Proc`
 
-   `get-proc`
+   `Get-Proc`
 
    This is a sample output that results from following these steps.
 
@@ -50,7 +50,7 @@ cmdlet is a simplified version of the `Get-Process` cmdlet that is provided by W
    ```
 
    ```powershell
-   Set-Content $env:temp\test.txt "This is a test file"
+   Set-Content $Env:TEMP\test.txt "This is a test file"
    ```
 
    ```output
@@ -177,7 +177,7 @@ namespace Microsoft.Samples.PowerShell.Commands
        {
            get
            {
-               return "This is a PowerShell snap-in that includes the get-proc cmdlet.";
+               return "This is a PowerShell snap-in that includes the Get-Proc cmdlet.";
            }
        }
    }

--- a/reference/docs-conceptual/developer/cmdlet/getprocesssample02-sample.md
+++ b/reference/docs-conceptual/developer/cmdlet/getprocesssample02-sample.md
@@ -38,7 +38,7 @@ is a simplified version of the `Get-Process` cmdlet provided by Windows PowerShe
 
 1. Run the following command to run the cmdlet:
 
-    `get-proc`
+    `Get-Proc`
 
 ## Requirements
 
@@ -70,7 +70,7 @@ namespace Microsoft.Samples.PowerShell.Commands
   #region GetProcCommand
 
   /// <summary>
-  /// This class implements the get-proc cmdlet.
+  /// This class implements the Get-Proc cmdlet.
   /// </summary>
   [Cmdlet(VerbsCommon.Get, "Proc")]
   public class GetProcCommand : Cmdlet

--- a/reference/docs-conceptual/developer/cmdlet/getprocesssample03-sample.md
+++ b/reference/docs-conceptual/developer/cmdlet/getprocesssample03-sample.md
@@ -39,7 +39,7 @@ version of the `Get-Process` cmdlet provided by Windows PowerShell 2.0.
 
 1. Run the following command to run the cmdlet:
 
-    `get-proc`
+    `Get-Proc`
 
 ## Requirements
 
@@ -74,7 +74,7 @@ namespace Microsoft.Samples.PowerShell.Commands
   #region GetProcCommand
 
   /// <summary>
-  /// This class implements the get-proc cmdlet.
+  /// This class implements the Get-Proc cmdlet.
   /// </summary>
   [Cmdlet(VerbsCommon.Get, "Proc")]
   public class GetProcCommand : Cmdlet

--- a/reference/docs-conceptual/developer/cmdlet/getprocesssample04-sample.md
+++ b/reference/docs-conceptual/developer/cmdlet/getprocesssample04-sample.md
@@ -38,7 +38,7 @@ simplified version of the `Get-Process` cmdlet provided by Windows PowerShell 2.
 
 1. Run the following command to run the cmdlet:
 
-    `get-proc`
+    `Get-Proc`
 
 ## Requirements
 
@@ -75,7 +75,7 @@ namespace Microsoft.Samples.PowerShell.Commands
    #region GetProcCommand
 
    /// <summary>
-   /// This class implements the get-proc cmdlet.
+   /// This class implements the Get-Proc cmdlet.
    /// </summary>
    [Cmdlet(VerbsCommon.Get, "Proc")]
    public class GetProcCommand : Cmdlet

--- a/reference/docs-conceptual/developer/cmdlet/getprocesssample05-sample.md
+++ b/reference/docs-conceptual/developer/cmdlet/getprocesssample05-sample.md
@@ -39,7 +39,7 @@ This sample shows a complete version of the Get-Proc cmdlet.
 
 1. Run the following command to run the cmdlet:
 
-   `get-proc`
+   `Get-Proc`
 
 ## Requirements
 
@@ -80,7 +80,7 @@ namespace Microsoft.Samples.PowerShell.Commands
     #region GetProcCommand
 
     /// <summary>
-   /// This class implements the get-proc cmdlet.
+   /// This class implements the Get-Proc cmdlet.
    /// </summary>
    [Cmdlet(VerbsCommon.Get, "Proc",
       DefaultParameterSetName = "ProcessName")]

--- a/reference/docs-conceptual/developer/cmdlet/how-to-declare-dynamic-parameters.md
+++ b/reference/docs-conceptual/developer/cmdlet/how-to-declare-dynamic-parameters.md
@@ -13,14 +13,14 @@ example, the `Department` parameter is added to the cmdlet whenever the user spe
 
 ## To define dynamic parameters
 
-1. In the cmdlet class declaration, add the [System.Management.Automation.Idynamicparameters][03]
+1. In the cmdlet class declaration, add the [System.Management.Automation.IDynamicParameters][03]
    interface as shown.
 
    ```csharp
    public class SendGreetingCommand : Cmdlet, IDynamicParameters
    ```
 
-1. Call the [System.Management.Automation.Idynamicparameters.Getdynamicparameters*][04] method,
+1. Call the [System.Management.Automation.IDynamicParameters.GetDynamicParameters*][04] method,
    which returns the object in which the dynamic parameters are defined. In this example, the method
    is called when the `Employee` parameter is specified.
 


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide