### PR TITLE
Fix incorrect case/capitalization in reference documents (37/38)

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-if.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-if.md
@@ -425,7 +425,7 @@ It evaluates to `$true` if there's a returned process and `$false` if there isn'
 perfectly valid to use pipeline expressions or other PowerShell statements like this:
 
 ```powershell
-if ( Get-Process | Where Name -eq Notepad )
+if ( Get-Process | where Name -EQ Notepad )
 ```
 
 These expressions can be combined with each other with the `-and` and `-or` operators, but you may
@@ -452,7 +452,7 @@ in diving deeper, I have an article about [everything you wanted to know about $
 I almost forgot to add this one until [Prasoon Karunan V][Prasoon Karunan V] reminded me of it.
 
 ```powershell
-if ($process=Get-Process notepad -ErrorAction ignore) {$process} else {$false}
+if ($process=Get-Process notepad -ErrorAction Ignore) {$process} else {$false}
 ```
 
 Normally when you assign a value to a variable, the value isn't passed onto the pipeline or
@@ -643,7 +643,7 @@ fall into the `$snowSqlParam` in the correct place. Same holds true for the `$Pa
 ## Simplify complex operations
 
 It's inevitable that you run into a situation that has way too many comparisons to check and your
-`If` statement scrolls way off the right side of the screen.
+`if` statement scrolls way off the right side of the screen.
 
 ```powershell
 $user = Get-ADUser -Identity $UserName

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
@@ -485,7 +485,7 @@ commands you use deal with the no results and error scenarios.
 ## Initializing to $null
 
 One habit that I have picked up is initializing all my variables before I use them. You are required
-to do this in other languages. At the top of my function or as I enter a `foreach loop`, I define
+to do this in other languages. At the top of my function or as I enter a `foreach` loop, I define
 all the values that I'm using.
 
 Here is a scenario that I want you to take a close look at. It's an example of a bug I had to chase

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
@@ -126,11 +126,11 @@ property, you get a `$null` value like you would for an undefined variable. It d
 variable is `$null` or an actual object in this case.
 
 ```powershell
-PS> $null -eq $undefined.some.fake.property
+PS> $null -eq $undefined.Some.Fake.Property
 True
 
 PS> $date = Get-Date
-PS> $null -eq $date.some.fake.property
+PS> $null -eq $date.Some.Fake.Property
 True
 ```
 
@@ -140,10 +140,10 @@ Calling a method on a `$null` object throws a `RuntimeException`.
 
 ```powershell
 PS> $value = $null
-PS> $value.toString()
+PS> $value.ToString()
 You cannot call a method on a null-valued expression.
 At line:1 char:1
-+ $value.tostring()
++ $value.ToString()
 + ~~~~~~~~~~~~~~~~~
     + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
     + FullyQualifiedErrorId : InvokeMethodOnNull
@@ -246,9 +246,9 @@ I ran into this issue when refactoring some code a few days ago. It had a basic 
 this.
 
 ```powershell
-if ( $object.property )
+if ( $object.Property )
 {
-    $object.property = $value
+    $object.Property = $value
 }
 ```
 
@@ -259,9 +259,9 @@ the property but it was a blank string value. This prevented it from ever gettin
 previous logic. So I added a proper `$null` check and everything worked.
 
 ```powershell
-if ( $null -ne $object.property )
+if ( $null -ne $object.Property )
 {
-    $object.property = $value
+    $object.Property = $value
 }
 ```
 
@@ -269,30 +269,30 @@ It's little bugs like these that are hard to spot and make me aggressively check
 
 ## $null.Count
 
-If you try to access a property on a `$null` value, that the property is also `$null`. The `count`
+If you try to access a property on a `$null` value, that the property is also `$null`. The `Count`
 property is the exception to this rule.
 
 ```powershell
 PS> $value = $null
-PS> $value.count
+PS> $value.Count
 0
 ```
 
-When you have a `$null` value, then the `count` is `0`. This special property is added by
+When you have a `$null` value, then the `Count` is `0`. This special property is added by
 PowerShell.
 
 ### [PSCustomObject] Count
 
-Almost all objects in PowerShell have that count property. One important exception is the
-`[PSCustomObject]` in Windows PowerShell 5.1 (This is fixed in PowerShell 6.0). It doesn't have a
-count property so you get a `$null` value if you try to use it. I call this out here so that you
-don't try to use `.Count` instead of a `$null` check.
+Almost all objects in PowerShell have that `Count` property. One important exception is the
+`[pscustomobject]` in Windows PowerShell 5.1 (This is fixed in PowerShell 6.0). It doesn't have a
+`Count` property so you get a `$null` value if you try to use it. I call this out here so that you
+don't try to use `Count` instead of a `$null` check.
 
 Running this example on Windows PowerShell 5.1 and PowerShell 6.0 gives you different results.
 
 ```powershell
-$value = [PSCustomObject]@{Name='MyObject'}
-if ( $value.count -eq 1 )
+$value = [pscustomobject]@{Name='MyObject'}
+if ( $value.Count -eq 1 )
 {
     "We have a value"
 }
@@ -318,19 +318,19 @@ required, the value is always `$null`. But if you place it inside an array, it's
 an empty array.
 
 ```powershell
-PS> $containempty = @( @() )
-PS> $containnothing = @($nothing)
-PS> $containnull = @($null)
+PS> $containEmpty = @( @() )
+PS> $containNothing = @($nothing)
+PS> $containNull = @($null)
 
-PS> $containempty.count
+PS> $containEmpty.Count
 0
-PS> $containnothing.count
+PS> $containNothing.Count
 0
-PS> $containnull.count
+PS> $containNull.Count
 1
 ```
 
-You can have an array that contains one `$null` value and its `count` is `1`. But if you place
+You can have an array that contains one `$null` value and its `Count` is `1`. But if you place
 an empty array inside an array then it's not counted as an item. The count is `0`.
 
 If you treat the enumerable null like a collection, then it's empty.
@@ -355,7 +355,7 @@ Depending on your code, you should account for the `$null` in your logic.
 
 Either check for `$null` first
 
-- Filter out null on the pipeline (`... | Where {$null -ne $_} | ...`)
+- Filter out null on the pipeline (`... | where {$null -ne $_} | ...`)
 - Handle it in the pipeline function
 
 ## foreach
@@ -372,7 +372,7 @@ foreach ( $node in $null )
 This saves me from having to `$null` check the collection before I enumerate it. If you have a
 collection of `$null` values, the `$node` can still be `$null`.
 
-The foreach started working this way with PowerShell 3.0. If you happen to be on an older version,
+The `foreach` started working this way with PowerShell 3.0. If you happen to be on an older version,
 then this is not the case. This is one of the important changes to be aware of when back-porting
 code for 2.0 compatibility.
 
@@ -420,7 +420,7 @@ it.
 function Do-Something
 {
     param(
-        [String] $Value
+        [string] $Value
     )
 }
 ```
@@ -485,8 +485,8 @@ commands you use deal with the no results and error scenarios.
 ## Initializing to $null
 
 One habit that I have picked up is initializing all my variables before I use them. You are required
-to do this in other languages. At the top of my function or as I enter a foreach loop, I define all
-the values that I'm using.
+to do this in other languages. At the top of my function or as I enter a `foreach loop`, I define
+all the values that I'm using.
 
 Here is a scenario that I want you to take a close look at. It's an example of a bug I had to chase
 down before.
@@ -498,7 +498,7 @@ function Do-Something
     {
         try
         {
-            $result = Get-Something -ID $node
+            $result = Get-Something -Id $node
         }
         catch
         {
@@ -521,7 +521,7 @@ to `$result`. It fails before the assignment so we don't even assign `$null` to 
 variable. `$result` still contains the previous valid `$result` from other iterations.
 `Update-Something` to execute multiple times on the same object in this example.
 
-I set `$result` to `$null` right inside the foreach loop before I use it to mitigate this issue.
+I set `$result` to `$null` right inside the `foreach` loop before I use it to mitigate this issue.
 
 ```powershell
 foreach ( $node in 1..6 )
@@ -557,7 +557,7 @@ function Do-Something
 {
     try
     {
-        $result = Get-Something -ID $node
+        $result = Get-Something -Id $node
     }
     catch
     {

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-pscustomobject.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-pscustomobject.md
@@ -18,12 +18,12 @@ better idea of what that means.
 
 ## Creating a PSCustomObject
 
-I love using `[PSCustomObject]` in PowerShell. Creating a usable object has never been easier.
+I love using `[pscustomobject]` in PowerShell. Creating a usable object has never been easier.
 Because of that, I'm going to skip over all the other ways you can create an object but I need
 to mention that most of these examples are PowerShell v3.0 and newer.
 
 ```powershell
-$myObject = [PSCustomObject]@{
+$myObject = [pscustomobject]@{
     Name     = 'Kevin'
     Language = 'PowerShell'
     State    = 'Texas'
@@ -32,7 +32,7 @@ $myObject = [PSCustomObject]@{
 
 This method works well for me because I use hashtables for just about everything. But there are
 times when I would like PowerShell to treat hashtables more like an object. The first place you
-notice the difference is when you want to use `Format-Table` or `Export-CSV` and you realize that a
+notice the difference is when you want to use `Format-Table` or `Export-Csv` and you realize that a
 hashtable is just a collection of key/value pairs.
 
 You can then access and use the values like you would a normal object.
@@ -73,7 +73,7 @@ $myHashtable = @{
     State    = 'Texas'
 }
 
-$myObject = New-Object -TypeName PSObject -Property $myHashtable
+$myObject = New-Object -TypeName psobject -Property $myHashtable
 ```
 
 This way is quite a bit slower but it may be your best option on early versions of PowerShell.
@@ -81,10 +81,10 @@ This way is quite a bit slower but it may be your best option on early versions 
 ### Saving to a file
 
 I find the best way to save a hashtable to a file is to save it as JSON. You can import it back into
-a `[PSCustomObject]`
+a `[pscustomobject]`
 
 ```powershell
-$myObject | ConvertTo-Json -depth 1 | Set-Content -Path $Path
+$myObject | ConvertTo-Json -Depth 1 | Set-Content -Path $Path
 $myObject = Get-Content -Path $Path | ConvertFrom-Json
 ```
 
@@ -108,7 +108,7 @@ $myObject.ID
 You can also remove properties off of an object.
 
 ```powershell
-$myObject.psobject.properties.remove('ID')
+$myObject.psobject.Properties.Remove('ID')
 ```
 
 The `.psobject` is an intrinsic member that gives you access to base object metadata. For more
@@ -120,13 +120,13 @@ information about intrinsic members, see
 Sometimes you need a list of all the property names on an object.
 
 ```powershell
-$myObject | Get-Member -MemberType NoteProperty | Select -ExpandProperty Name
+$myObject | Get-Member -MemberType NoteProperty | select -ExpandProperty Name
 ```
 
 We can get this same list off of the `psobject` property too.
 
 ```powershell
-$myobject.psobject.properties.name
+$myobject.psobject.Properties.Name
 ```
 
 > [!NOTE]
@@ -163,7 +163,7 @@ from them.
 
 ```powershell
 $hashtable = @{}
-foreach( $property in $myobject.psobject.properties.name )
+foreach( $property in $myobject.psobject.Properties.Name )
 {
     $hashtable[$property] = $myObject.$property
 }
@@ -178,10 +178,10 @@ if( $null -ne $myObject.ID )
 ```
 
 But if the value could be `$null` you can check to see if it exists by checking the
-`psobject.properties` for it.
+`psobject.Properties` for it.
 
 ```powershell
-if( $myobject.psobject.properties.match('ID').Count )
+if( $myobject.psobject.Properties.Match('ID').Count )
 ```
 
 ## Adding object methods
@@ -193,7 +193,7 @@ If you need to add a script method to an object, you can do it with `Add-Member`
 ```powershell
 $ScriptBlock = {
     $hashtable = @{}
-    foreach( $property in $this.psobject.properties.name )
+    foreach( $property in $this.psobject.Properties.Name )
     {
         $hashtable[$property] = $this.$property
     }
@@ -236,7 +236,7 @@ Object variables hold a reference to the actual object. When you assign one obje
 variable, they still reference the same object.
 
 ```powershell
-$third = [PSCustomObject]@{Key=3}
+$third = [pscustomobject]@{Key=3}
 $fourth = $third
 $fourth.Key = 4
 ```
@@ -244,13 +244,13 @@ $fourth.Key = 4
 Because `$third` and `$fourth` reference the same instance of an object, both `$third.key` and
 `$fourth.Key` are 4.
 
-### psobject.copy()
+### psobject.Copy()
 
 If you need a true copy of an object, you can clone it.
 
 ```powershell
-$third = [PSCustomObject]@{Key=3}
-$fourth = $third.psobject.copy()
+$third = [pscustomobject]@{Key=3}
+$fourth = $third.psobject.Copy()
 $fourth.Key = 4
 ```
 
@@ -267,14 +267,14 @@ obvious. First thing we need to do is give it a `PSTypeName`. This is the most c
 people do it:
 
 ```powershell
-$myObject.PSObject.TypeNames.Insert(0,"My.Object")
+$myObject.psobject.TypeNames.Insert(0,"My.Object")
 ```
 
 I recently discovered another way to do this from Redditor `u/markekraus`. He talks about this
 approach that allows you to define it inline.
 
 ```powershell
-$myObject = [PSCustomObject]@{
+$myObject = [pscustomobject]@{
     PSTypeName = 'My.Object'
     Name       = 'Kevin'
     Language   = 'PowerShell'
@@ -337,7 +337,7 @@ $TypeData = @{
     TypeName = 'My.Object'
     MemberType = 'ScriptProperty'
     MemberName = 'UpperCaseName'
-    Value = {$this.Name.toUpper()}
+    Value = {$this.Name.ToUpper()}
 }
 Update-TypeData @TypeData
 ```
@@ -388,7 +388,7 @@ to the pipe when they shouldn't.
 
 ## Closing thoughts
 
-The context of this was all about `[PSCustomObject]`, but a lot of this information applies to
+The context of this was all about `[pscustomobject]`, but a lot of this information applies to
 objects in general.
 
 I have seen most of these features in passing before but never saw them presented as a collection of

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
@@ -181,7 +181,7 @@ function Test-ShouldProcess {
 }
 ```
 
-The call to `$PSCmdlet.ShouldProcess($file.name)` checks for the `-WhatIf` (and `-Confirm`
+The call to `$PSCmdlet.ShouldProcess($file.Name)` checks for the `-WhatIf` (and `-Confirm`
 parameter) then handles it accordingly. The `-WhatIf` causes `ShouldProcess` to output a
 description of the change and return `$false`:
 
@@ -298,7 +298,7 @@ if ($PSCmdlet.ShouldProcess('TARGET','OPERATION')){
 ```
 
 If I'm processing a collection of items, I call it for each item. So the call gets placed inside
-the foreach loop.
+the `foreach` loop.
 
 ```powershell
 foreach ($node in $collection){
@@ -567,7 +567,7 @@ This is the correct way to implement `-Force` with `ShouldContinue`.
 function Test-ShouldContinue {
     [CmdletBinding()]
     param(
-        [Switch]$Force
+        [switch]$Force
     )
 
     if($Force -or $PSCmdlet.ShouldContinue('TARGET','OPERATION')){
@@ -577,7 +577,7 @@ function Test-ShouldContinue {
 ```
 
 By placing the `$Force` to the left of the `-or` operator, it gets evaluated first. Writing it
-this way short circuits the execution of the `if` statement. If `$force` is `$true`, then the
+this way short circuits the execution of the `if` statement. If `$Force` is `$true`, then the
 `ShouldContinue` is not executed.
 
 ```powershell

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-string-substitutions.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-string-substitutions.md
@@ -60,12 +60,12 @@ is where many new people get tripped up. First let me show you what they think s
 face value almost looks like it should).
 
 ```powershell
-$directory = Get-Item 'c:\windows'
+$directory = Get-Item 'C:\windows'
 $message = "Time: $directory.CreationTime"
 ```
 
 You would be expecting to get the `CreationTime` off of the `$directory`, but instead you get this
-`Time: c:\windows.CreationTime` as your value. The reason is that this type of substitution only
+`Time: C:\windows.CreationTime` as your value. The reason is that this type of substitution only
 sees the base variable. It considers the period as part of the string so it stops resolving the
 value any deeper.
 
@@ -175,7 +175,7 @@ This is often overlooked but a great cmdlet for building a file path.
 
 ```powershell
 $folder = 'Temp'
-Join-Path -Path 'c:\windows' -ChildPath $folder
+Join-Path -Path 'C:\windows' -ChildPath $folder
 ```
 
 The great thing about this is it works out the backslashes correctly when it puts the values
@@ -296,7 +296,7 @@ $name = 'Kevin Marquette'
 $string = $ExecutionContext.InvokeCommand.ExpandString($message)
 ```
 
-The call to `.InvokeCommand.ExpandString` on the current execution context uses the variables in
+The call to `InvokeCommand.ExpandString` on the current execution context uses the variables in
 the current scope for substitution. The key thing here is that the `$message` can be defined very
 early before the variables even exist.
 

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-switch.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-switch.md
@@ -281,7 +281,7 @@ advanced processing.
 The `switch` can be on an expression instead of a variable.
 
 ``` powershell
-switch ( ( Get-Service | Where status -eq 'running' ).name ) {...}
+switch ( ( Get-Service | where Status -EQ 'running' ).Name ) {...}
 ```
 
 Whatever the expression evaluates to is the value used for the match.
@@ -411,7 +411,7 @@ switch -Wildcard ($Messages)
 ```Output
 Downloading update
 WARNING: Ran into errors downloading file
-write-error -message $PSItem : Error: out of disk space
+Write-Error -Message $PSItem : Error: out of disk space
 + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
 + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException
 ```
@@ -768,7 +768,7 @@ If I'm only using a `switch` as a lookup, I often use a `hashtable` instead.
 
 ### Enum
 
-PowerShell 5.0 introduced the `Enum` and it's also an option in this case.
+PowerShell 5.0 introduced the `enum` and it's also an option in this case.
 
 ``` powershell
 $day = 3

--- a/reference/docs-conceptual/learn/deep-dives/write-progress-across-multiple-threads.md
+++ b/reference/docs-conceptual/learn/deep-dives/write-progress-across-multiple-threads.md
@@ -1,14 +1,14 @@
 ---
-description: How to use Write-Progress across multiple threads with Foreach-Object -Parallel
+description: How to use Write-Progress across multiple threads with ForEach-Object -Parallel
 ms.date: 11/16/2022
 title: Displaying progress while multi-threading
 ---
 
-# Writing Progress across multiple threads with Foreach Parallel
+# Writing Progress across multiple threads with `ForEach-Object -Parallel`
 
 Starting in PowerShell 7.0, the ability to work in multiple threads simultaneously is possible using
 the **Parallel** parameter in the
-[Foreach-Object](/powershell/module/Microsoft.PowerShell.Core/Foreach-Object) cmdlet. Monitoring the
+[ForEach-Object](/powershell/module/Microsoft.PowerShell.Core/ForEach-Object) cmdlet. Monitoring the
 progress of these threads can be a challenge though. Normally, you can monitor the progress of a
 process using [Write-Progress](/powershell/module/Microsoft.PowerShell.Utility/Write-Progress).
 However, since PowerShell uses a separate runspace for each thread when using **Parallel**,
@@ -31,30 +31,30 @@ runs without error.
 $dataset = @(
     @{
         Id   = 1
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 2
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 3
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 4
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 5
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
 )
 
 # Create a hashtable for process.
 # Keys should be ID's of the processes
 $origin = @{}
-$dataset | Foreach-Object {$origin.($_.id) = @{}}
+$dataset | ForEach-Object {$origin.($_.Id) = @{}}
 
 # Create synced hashtable
 $sync = [System.Collections.Hashtable]::Synchronized($origin)
@@ -79,8 +79,8 @@ This section runs the multi-threaded processes and creates some of the output us
 progress.
 
 ```powershell
-$job = $dataset | Foreach-Object -ThrottleLimit 3 -AsJob -Parallel {
-    $syncCopy = $using:sync
+$job = $dataset | ForEach-Object -ThrottleLimit 3 -AsJob -Parallel {
+    $syncCopy = $Using:sync
     $process = $syncCopy.$($PSItem.Id)
 
     $process.Id = $PSItem.Id
@@ -88,10 +88,10 @@ $job = $dataset | Foreach-Object -ThrottleLimit 3 -AsJob -Parallel {
     $process.Status = "Processing"
 
     # Fake workload start up that takes x amount of time to complete
-    start-sleep -Milliseconds ($PSItem.wait*5)
+    Start-Sleep -Milliseconds ($PSItem.Wait*5)
 
     # Process. update activity
-    $process.Activity = "Id $($PSItem.id) processing"
+    $process.Activity = "Id $($PSItem.Id) processing"
     foreach ($percent in 1..100)
     {
         # Update process on status
@@ -107,13 +107,13 @@ $job = $dataset | Foreach-Object -ThrottleLimit 3 -AsJob -Parallel {
 }
 ```
 
-The mock processes are sent to `Foreach-Object` and started as jobs. The **ThrottleLimit** is set to
+The mock processes are sent to `ForEach-Object` and started as jobs. The **ThrottleLimit** is set to
 **3** to highlight running multiple processes in a queue. The jobs are stored in the `$job` variable
 and allows us to know when all the processes have finished later on.
 
-When using the `using:` statement to reference a parent scope variable in PowerShell, you can't use
+When using the `Using:` statement to reference a parent scope variable in PowerShell, you can't use
 expressions to make it dynamic. For example, if you tried to create the `$process` variable like
-this, `$process = $using:sync.$($PSItem.id)`, you would get an error stating you can't use
+this, `$process = $Using:sync.$($PSItem.Id)`, you would get an error stating you can't use
 expressions there. So, we create the `$syncCopy` variable to be able to reference and modify the
 `$sync` variable without the risk of it failing.
 
@@ -134,9 +134,9 @@ PowerShell window.
 ```powershell
 while($job.State -eq 'Running')
 {
-    $sync.Keys | Foreach-Object {
+    $sync.Keys | ForEach-Object {
         # If key is not defined, ignore
-        if(![string]::IsNullOrEmpty($sync.$_.keys))
+        if(![string]::IsNullOrEmpty($sync.$_.Keys))
         {
             # Create parameter hashtable to splat
             $param = $sync.$_
@@ -172,36 +172,36 @@ hashtable from the current key is used to splat the parameters to `Write-Progres
 $dataset = @(
     @{
         Id   = 1
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 2
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 3
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 4
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
     @{
         Id   = 5
-        Wait = 3..10 | get-random | Foreach-Object {$_*100}
+        Wait = 3..10 | Get-Random | ForEach-Object {$_*100}
     }
 )
 
 # Create a hashtable for process.
 # Keys should be ID's of the processes
 $origin = @{}
-$dataset | Foreach-Object {$origin.($_.id) = @{}}
+$dataset | ForEach-Object {$origin.($_.Id) = @{}}
 
 # Create synced hashtable
 $sync = [System.Collections.Hashtable]::Synchronized($origin)
 
-$job = $dataset | Foreach-Object -ThrottleLimit 3 -AsJob -Parallel {
-    $syncCopy = $using:sync
+$job = $dataset | ForEach-Object -ThrottleLimit 3 -AsJob -Parallel {
+    $syncCopy = $Using:sync
     $process = $syncCopy.$($PSItem.Id)
 
     $process.Id = $PSItem.Id
@@ -209,10 +209,10 @@ $job = $dataset | Foreach-Object -ThrottleLimit 3 -AsJob -Parallel {
     $process.Status = "Processing"
 
     # Fake workload start up that takes x amount of time to complete
-    start-sleep -Milliseconds ($PSItem.wait*5)
+    Start-Sleep -Milliseconds ($PSItem.Wait*5)
 
     # Process. update activity
-    $process.Activity = "Id $($PSItem.id) processing"
+    $process.Activity = "Id $($PSItem.Id) processing"
     foreach ($percent in 1..100)
     {
         # Update process on status
@@ -229,9 +229,9 @@ $job = $dataset | Foreach-Object -ThrottleLimit 3 -AsJob -Parallel {
 
 while($job.State -eq 'Running')
 {
-    $sync.Keys | Foreach-Object {
+    $sync.Keys | ForEach-Object {
         # If key is not defined, ignore
-        if(![string]::IsNullOrEmpty($sync.$_.keys))
+        if(![string]::IsNullOrEmpty($sync.$_.Keys))
         {
             # Create parameter hashtable to splat
             $param = $sync.$_

--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -196,19 +196,19 @@ This feature was added in PowerShell 7.4-preview.1.
 > [!NOTE]
 > This experimental feature was added in PowerShell 7.5-preview.4.
 
-When enabled, this feature adds support for redirecting to the variable drive. This feature allows
-you to redirect data to a variable using the `variable:name` syntax. PowerShell inspects the target
-of the redirection and if it uses the variable provider it calls `Set-Variable` rather than
+When enabled, this feature adds support for redirecting to the Variable: drive. This feature allows
+you to redirect data to a variable using the `Variable:name` syntax. PowerShell inspects the target
+of the redirection and if it uses the Variable provider it calls `Set-Variable` rather than
 `Out-File`.
 
-The following example shows how to redirect the output of a command to a variable:
+The following example shows how to redirect the output of a command to a Variable:
 
 ```powershell
 . {
     "Output 1"
     Write-Warning "Warning, Warning!"
     "Output 2"
-} 3> variable:warnings
+} 3> Variable:warnings
 $warnings
 ```
 

--- a/reference/docs-conceptual/learn/ps101/02-help-system.md
+++ b/reference/docs-conceptual/learn/ps101/02-help-system.md
@@ -391,7 +391,7 @@ first position (position zero) when used positionally.
     function help and script help articles.
 
     To get help for a script that isn't located in a path that's listed in
-    the `$env:Path` environment variable, type the script's path and file
+    the `$Env:PATH` environment variable, type the script's path and file
     name.
 
     If you enter the exact name of a help article, `Get-Help` displays the
@@ -633,7 +633,7 @@ SYNTAX
 
 DESCRIPTION
     > This cmdlet is only available on the Windows platform. The
-    `Get-Hotfix` cmdlet uses the Win32_QuickFixEngineering WMI class to
+    `Get-HotFix` cmdlet uses the Win32_QuickFixEngineering WMI class to
     list hotfixes that are installed on the local computer or specified
     remote computers.
 
@@ -648,10 +648,10 @@ RELATED LINKS
     Win32_QuickFixEngineering class
 
 REMARKS
-    To see the examples, type: "get-help Get-HotFix -examples".
-    For more information, type: "get-help Get-HotFix -detailed".
-    For technical information, type: "get-help Get-HotFix -full".
-    For online help, type: "get-help Get-HotFix -online"
+    To see the examples, type: "Get-Help Get-HotFix -Examples".
+    For more information, type: "Get-Help Get-HotFix -Detailed".
+    For technical information, type: "Get-Help Get-HotFix -Full".
+    For online help, type: "Get-Help Get-HotFix -Online"
 ```
 
 You can also find commands that lack help articles with `Get-Help`, although this capability isn't

--- a/reference/docs-conceptual/learn/ps101/03-discovering-objects.md
+++ b/reference/docs-conceptual/learn/ps101/03-discovering-objects.md
@@ -282,7 +282,7 @@ To retrieve information about the PowerShell process running on your lab environ
 the `Get-Process` cmdlet.
 
 ```powershell
-Get-Process -Name PowerShell
+Get-Process -Name powershell
 ```
 
 ```Output
@@ -294,7 +294,7 @@ Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
 To determine the available properties, pipe `Get-Process` to `Get-Member`.
 
 ```powershell
-Get-Process -Name PowerShell | Get-Member
+Get-Process -Name powershell | Get-Member
 ```
 
 When using the `Get-Process` command, you might notice that some properties displayed by default are

--- a/reference/docs-conceptual/learn/ps101/04-pipelines.md
+++ b/reference/docs-conceptual/learn/ps101/04-pipelines.md
@@ -35,7 +35,7 @@ the flow of the pipeline.
 
 ```powershell
 Get-Service |
-    Where-Object CanPauseAndContinue -eq $true |
+    Where-Object CanPauseAndContinue -EQ $true |
     Select-Object -Property *
 ```
 
@@ -298,7 +298,7 @@ to filter its results. This technique is inefficient if an earlier command in th
 parameter to perform the filtering.
 
 ```powershell
-Get-Service | Where-Object Name -eq w32time
+Get-Service | Where-Object Name -EQ w32time
 ```
 
 ```Output
@@ -593,7 +593,7 @@ understanding and retention of the syntax.
 
 ```powershell
 $customObject |
-    Select-Object -Property @{name='Name';expression={$_.Service}} |
+    Select-Object -Property @{Name='Name';Expression={$_.Service}} |
     Stop-Service
 ```
 
@@ -604,14 +604,14 @@ use the saved data as input for another command.
 
 ```powershell
 'Background Intelligent Transfer Service', 'Windows Time' |
-    Out-File -FilePath $env:TEMP\services.txt
+    Out-File -FilePath $Env:TEMP\services.txt
 ```
 
 You can use parentheses to pass the output of one command as input for a parameter to another
 command.
 
 ```powershell
-Stop-Service -DisplayName (Get-Content -Path $env:TEMP\services.txt)
+Stop-Service -DisplayName (Get-Content -Path $Env:TEMP\services.txt)
 ```
 
 This concept is like the order of operations in Algebra. Just as mathematical operations within

--- a/reference/docs-conceptual/learn/ps101/05-formatting-aliases-providers-comparison.md
+++ b/reference/docs-conceptual/learn/ps101/05-formatting-aliases-providers-comparison.md
@@ -368,15 +368,15 @@ comparison operator.
 | `-ge`          | Greater than or equal to                                    |
 | `-lt`          | Less than                                                   |
 | `-le`          | Less than or equal to                                       |
-| `-Like`        | Match using the `*` wildcard character                      |
-| `-NotLike`     | Doesn't match using the `*` wildcard character              |
-| `-Match`       | Matches the specified regular expression                    |
-| `-NotMatch`    | Doesn't match the specified regular expression              |
-| `-Contains`    | Determines if a collection contains a specified value       |
-| `-NotContains` | Determines if a collection doesn't contain a specific value |
-| `-In`          | Determines if a specified value is in a collection          |
-| `-NotIn`       | Determines if a specified value isn't in a collection       |
-| `-Replace`     | Replaces the specified value                                |
+| `-like`        | Match using the `*` wildcard character                      |
+| `-notlike`     | Doesn't match using the `*` wildcard character              |
+| `-match`       | Matches the specified regular expression                    |
+| `-notmatch`    | Doesn't match the specified regular expression              |
+| `-contains`    | Determines if a collection contains a specified value       |
+| `-notcontains` | Determines if a collection doesn't contain a specific value |
+| `-in`          | Determines if a specified value is in a collection          |
+| `-notin`       | Determines if a specified value isn't in a collection       |
+| `-replace`     | Replaces the specified value                                |
 
 Proper case "PowerShell" is equal to lower case "powershell" using the equals comparison operator.
 
@@ -441,7 +441,7 @@ less than or equal to work.
 True
 ```
 
-The `-Like` and `-Match` operators can be confusing, even for experienced PowerShell users. `-Like`
+The `-like` and `-match` operators can be confusing, even for experienced PowerShell users. `-like`
 is used with the wildcard characters `*` and `?` to perform "like" matches.
 
 ```powershell
@@ -452,7 +452,7 @@ is used with the wildcard characters `*` and `?` to perform "like" matches.
 True
 ```
 
-`-Match` uses a regular expression to perform the matching.
+The `-match` operator uses a regular expression to perform the matching.
 
 ```powershell
 'PowerShell' -match '^.*shell$'
@@ -488,7 +488,8 @@ $Numbers -contains 10
 True
 ```
 
-`-NotContains` reverses the logic to see if the `$Numbers` variable doesn't contain a value.
+The `-notcontains` operator reverses the logic to see if the `$Numbers` variable doesn't contain a
+value.
 
 ```powershell
 $Numbers -notcontains 15
@@ -585,7 +586,7 @@ to replace. SQL Saturday in Baton Rouge is an event I try to speak at every year
 example, the word "Saturday" is replaced with the abbreviation "Sat".
 
 ```powershell
-'SQL Saturday - Baton Rouge' -Replace 'saturday','Sat'
+'SQL Saturday - Baton Rouge' -replace 'saturday','Sat'
 ```
 
 ```Output
@@ -593,7 +594,7 @@ SQL Sat - Baton Rouge
 ```
 
 There are also methods like **Replace()** that can be used to replace things similar to how the
-replace operator works. However, the `-Replace` operator is case-insensitive by default, and the
+replace operator works. However, the `-replace` operator is case-insensitive by default, and the
 **Replace()** method is case-sensitive.
 
 ```powershell
@@ -636,7 +637,7 @@ Comparison Operators.
 1. Why is it necessary to perform formatting as far to the right as possible?
 1. How do you determine what the actual cmdlet is for the `%` alias?
 1. Why shouldn't you use aliases in scripts you save or code you share with others?
-1. Perform a directory listing on the drives that are associated with one of the registry providers.
+1. Perform a directory listing on the drives that are associated with the Registry provider.
 1. What's one of the main benefits of using the replace operator instead of the replace method?
 
 ## References

--- a/reference/docs-conceptual/learn/ps101/06-flow-control.md
+++ b/reference/docs-conceptual/learn/ps101/06-flow-control.md
@@ -307,8 +307,8 @@ In this chapter, you learned about the different types of loops that exist in Po
 
 ## Review
 
-1. What is the difference between the `ForEach-Object` cmdlet and the `foreach` statement?
-1. What is the primary advantage of using a `while` loop instead of a `do while` or `do until` loop?
+1. What's the difference between the `ForEach-Object` cmdlet and the `foreach` statement?
+1. What's the primary advantage of using a `while` loop instead of a `do while` or `do until` loop?
 1. How do the `break` and `continue` statements differ?
 
 ## References

--- a/reference/docs-conceptual/learn/ps101/06-flow-control.md
+++ b/reference/docs-conceptual/learn/ps101/06-flow-control.md
@@ -12,7 +12,7 @@ title: Flow control
 
 When you move from writing PowerShell one-liners to writing scripts, it sounds more complicated than
 it is. A script is nothing more than the same or similar commands you run interactively in the
-PowerShell console, except you save them as a `.PS1` file. There are some scripting constructs that
+PowerShell console, except you save them as a `.ps1` file. There are some scripting constructs that
 you might use, such as a `foreach` loop instead of the `ForEach-Object` cmdlet. The differences can
 be confusing for beginners when considering that `foreach` is both a language keyword and an
 alias for the `ForEach-Object` cmdlet.
@@ -214,7 +214,7 @@ What's your guess?: 4
 
 The same results are achieved with a `Do While` loop by reversing the test condition to not equals.
 
-`Do` loops always run at least once because the condition is evaluated at the end of the loop.
+`do` loops always run at least once because the condition is evaluated at the end of the loop.
 
 ### While
 
@@ -280,7 +280,7 @@ while ($i -lt 5) {
 5
 ```
 
-`Return` is designed to exit out of the existing scope.
+The `return` keyword is designed to exit out of the existing scope.
 
 Notice in the following example that `return` outputs the first result and then exits out of the
 loop.
@@ -307,20 +307,20 @@ In this chapter, you learned about the different types of loops that exist in Po
 
 ## Review
 
-1. What's the difference between the `ForEach-Object` cmdlet and the `foreach` scripting construct?
-1. What's the primary advantage of using a `While` loop instead of a `Do While` or `Do Until` loop?
+1. What is the difference between the `ForEach-Object` cmdlet and the `foreach` statement?
+1. What is the primary advantage of using a `while` loop instead of a `do while` or `do until` loop?
 1. How do the `break` and `continue` statements differ?
 
 ## References
 
-- [ForEach-Object][foreach-object]
-- [about_ForEach][about-foreach]
-- [about_For][about-for]
-- [about_Do][about-do]
-- [about_While][about-while]
-- [about_Break][about-break]
-- [about_Continue][about-continue]
-- [about_Return][about-return]
+- [ForEach-Object][ForEach-Object]
+- [about_Foreach][about_Foreach]
+- [about_For][about_For]
+- [about_Do][about_Do]
+- [about_While][about_While]
+- [about_Break][about_Break]
+- [about_Continue][about_Continue]
+- [about_Return][about_Return]
 
 <!-- link references -->
 

--- a/reference/docs-conceptual/learn/ps101/07-working-with-wmi.md
+++ b/reference/docs-conceptual/learn/ps101/07-working-with-wmi.md
@@ -73,7 +73,7 @@ WMI, such as in the following example.
 ```vb
 strComputer = "."
 Set objWMIService = GetObject("winmgmts:" _
-    & "{impersonationLevel=impersonate}!\\" & strComputer & "\root\cimv2")
+    & "{impersonationLevel=impersonate}!\\" & strComputer & "\root\CIMV2")
 
 Set colBIOS = objWMIService.ExecQuery _
     ("Select * from Win32_BIOS")

--- a/reference/docs-conceptual/learn/ps101/08-powershell-remoting.md
+++ b/reference/docs-conceptual/learn/ps101/08-powershell-remoting.md
@@ -54,7 +54,7 @@ Cmdlet          Test-Connection                3.1.0.0    Microsoft.PowerShell.M
 Cmdlet          Write-EventLog                 3.1.0.0    Microsoft.PowerShell.Management
 ```
 
-Commands such as `Get-Process` and `Get-Hotfix` have a **ComputerName** parameter. This isn't the
+Commands such as `Get-Process` and `Get-HotFix` have a **ComputerName** parameter. This isn't the
 long-term direction that Microsoft is heading for running commands against remote computers. Even if
 you find a command that has a **ComputerName** parameter, chances are that you'll need to specify
 alternate credentials and it won't have a **Credential** parameter. And if you decided to run

--- a/reference/docs-conceptual/learn/ps101/09-functions.md
+++ b/reference/docs-conceptual/learn/ps101/09-functions.md
@@ -12,7 +12,7 @@ PowerShell one-liners and scripts that have to be modified often are good candid
 reusable functions.
 
 Write functions whenever possible because they're more tool-oriented. You can add the functions to a
-script module, put that module in a location defined in the `$env:PSModulePath`, and call the
+script module, put that module in a location defined in the `$Env:PSModulePath`, and call the
 functions without needing to locate where you saved the functions. Using the **PowerShellGet**
 module, it's easy to share your PowerShell modules in a NuGet repository. **PowerShellGet** ships
 with PowerShell version 5.0 and higher. It's also available as a separate download for PowerShell
@@ -559,7 +559,7 @@ The problem is that default values can't be used with mandatory parameters. Inst
 `ValidateNotNullOrEmpty` parameter validation attribute with a default value.
 
 Even when setting a default value, try not to use static values. In the following example,
-`$env:COMPUTERNAME` is used as the default value, which is automatically translated to the local
+`$Env:COMPUTERNAME` is used as the default value, which is automatically translated to the local
 computer name if a value isn't provided.
 
 ```powershell
@@ -568,7 +568,7 @@ function Test-MrParameterValidation {
     [CmdletBinding()]
     param (
         [ValidateNotNullOrEmpty()]
-        [string[]]$ComputerName = $env:COMPUTERNAME
+        [string[]]$ComputerName = $Env:COMPUTERNAME
     )
 
     Write-Output $ComputerName
@@ -591,7 +591,7 @@ function Test-MrVerboseOutput {
     [CmdletBinding()]
     param (
         [ValidateNotNullOrEmpty()]
-        [string[]]$ComputerName = $env:COMPUTERNAME
+        [string[]]$ComputerName = $Env:COMPUTERNAME
     )
 
     foreach ($Computer in $ComputerName) {
@@ -611,7 +611,7 @@ function Test-MrVerboseOutput {
     [CmdletBinding()]
     param (
         [ValidateNotNullOrEmpty()]
-        [string[]]$ComputerName = $env:COMPUTERNAME
+        [string[]]$ComputerName = $Env:COMPUTERNAME
     )
 
     foreach ($Computer in $ComputerName) {

--- a/reference/docs-conceptual/learn/ps101/10-script-modules.md
+++ b/reference/docs-conceptual/learn/ps101/10-script-modules.md
@@ -15,7 +15,7 @@ makes them look and feel more professional and makes them easier to share.
 
 Something that we didn't talk about in the previous chapter is dot-sourcing functions. When a
 function in a script isn't part of a module, the only way to load it into memory is to dot-source
-the `.PS1` file that it's saved in.
+the `.ps1` file that it's saved in.
 
 The following function has been saved as `Get-MrPSVersion.ps1`.
 
@@ -106,7 +106,7 @@ Function        Get-MrPSVersion
 ## Script Modules
 
 A script module in PowerShell is simply a file containing one or more functions that's saved as a
-`.PSM1` file instead of a `.PS1` file.
+`.psm1` file instead of a `.ps1` file.
 
 How do you create a script module? You're probably guessing with a command named something like
 `New-Module`. Your assumption would be wrong. While there is a command in PowerShell named
@@ -160,10 +160,10 @@ RELATED LINKS
     Remove-Module
 
 REMARKS
-    To see the examples, type: "get-help New-Module -examples".
-    For more information, type: "get-help New-Module -detailed".
-    For technical information, type: "get-help New-Module -full".
-    For online help, type: "get-help New-Module -online"
+    To see the examples, type: "Get-Help New-Module -Examples".
+    For more information, type: "Get-Help New-Module -Detailed".
+    For technical information, type: "Get-Help New-Module -Full".
+    For online help, type: "Get-Help New-Module -Online"
 ```
 
 In the previous chapter, I mentioned that functions should use approved verbs otherwise they'll
@@ -175,7 +175,7 @@ New-Module -Name MyModule -ScriptBlock {
 
     function Return-MrOsVersion {
         Get-CimInstance -ClassName Win32_OperatingSystem |
-        Select-Object -Property @{label='OperatingSystem';expression={$_.Caption}}
+        Select-Object -Property @{Label='OperatingSystem';Expression={$_.Caption}}
     }
 
     Export-ModuleMember -Function Return-MrOsVersion
@@ -201,7 +201,7 @@ function Get-MrPSVersion {
 }
 
 function Get-MrComputerName {
-    $env:COMPUTERNAME
+    $Env:COMPUTERNAME
 }
 ```
 
@@ -232,11 +232,11 @@ Import-Module C:\MyScriptModule.psm1
 ```
 
 The module autoloading feature was introduced in PowerShell version 3. To take advantage of module
-autoloading, a script module needs to be saved in a folder with the same base name as the `.PSM1` file
-and in a location specified in `$env:PSModulePath`.
+autoloading, a script module needs to be saved in a folder with the same base name as the `.psm1`
+file and in a location specified in `$Env:PSModulePath`.
 
 ```powershell
-$env:PSModulePath
+$Env:PSModulePath
 ```
 
 ```Output
@@ -249,7 +249,7 @@ The results are difficult to read. Since the paths are separated by a semicolon,
 results to return each path on a separate line. This makes them easier to read.
 
 ```powershell
-$env:PSModulePath -split ';'
+$Env:PSModulePath -split ';'
 ```
 
 ```Output
@@ -272,13 +272,13 @@ The second path is the **AllUsers** path. This is the location where I store all
 The third path is underneath `C:\Windows\System32`. Only Microsoft should be storing modules in that
 location since it resides within the operating systems folder.
 
-Once the `.PSM1` file is located in the correct path, the module will load automatically when one of
+Once the `.psm1` file is located in the correct path, the module will load automatically when one of
 its commands is called.
 
 ## Module Manifests
 
 All modules should have a module manifest. A module manifest contains metadata about your module.
-The file extension for a module manifest file is `.PSD1`. Not all files with a `.PSD1` extension are
+The file extension for a module manifest file is `.psd1`. Not all files with a `.psd1` extension are
 module manifests. They can also be used for things such as storing the environmental portion of a
 DSC configuration. `New-ModuleManifest` is used to create a module manifest. **Path** is the only
 value that's required. However, the module won't work if **RootModule** isn't specified. It's a good
@@ -301,7 +301,7 @@ Script     0.0        myscriptmodule                      {Get-MrComputerName, G
 The module manifest can be created with all of the recommended information.
 
 ```powershell
-New-ModuleManifest -Path $env:ProgramFiles\WindowsPowerShell\Modules\MyScriptModule\MyScriptModule.psd1 -RootModule MyScriptModule -Author 'Mike F Robbins' -Description 'MyScriptModule' -CompanyName 'mikefrobbins.com'
+New-ModuleManifest -Path $Env:ProgramFiles\WindowsPowerShell\Modules\MyScriptModule\MyScriptModule.psd1 -RootModule MyScriptModule -Author 'Mike F Robbins' -Description 'MyScriptModule' -CompanyName 'mikefrobbins.com'
 ```
 
 If any of this information is missed during the initial creation of the module manifest, it can be
@@ -314,7 +314,7 @@ You may have helper functions that you may want to be private and only accessibl
 within the module. They are not intended to be accessible to users of your module. There are a
 couple of different ways to accomplish this.
 
-If you're not following the best practices and only have a `.PSM1` file, then your only option is to
+If you're not following the best practices and only have a `.psm1` file, then your only option is to
 use the `Export-ModuleMember` cmdlet.
 
 ```powershell
@@ -323,7 +323,7 @@ function Get-MrPSVersion {
 }
 
 function Get-MrComputerName {
-    $env:COMPUTERNAME
+    $Env:COMPUTERNAME
 }
 
 Export-ModuleMember -Function Get-MrPSVersion
@@ -350,7 +350,7 @@ individual functions you want to export in the **FunctionsToExport** section of 
 FunctionsToExport = 'Get-MrPSVersion'
 ```
 
-It's not necessary to use both `Export-ModuleMember` in the `.PSM1` file and the
+It's not necessary to use both `Export-ModuleMember` in the `.psm1` file and the
 **FunctionsToExport** section of the module manifest. One or the other is sufficient.
 
 ## Summary

--- a/reference/docs-conceptual/learn/shell/creating-profiles.md
+++ b/reference/docs-conceptual/learn/shell/creating-profiles.md
@@ -124,7 +124,7 @@ function prompt {
     $principal = [Security.Principal.WindowsPrincipal] $identity
     $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
 
-    $prefix = if (Test-Path variable:/PSDebugContext) { '[DBG]: ' } else { '' }
+    $prefix = if (Test-Path Variable:/PSDebugContext) { '[DBG]: ' } else { '' }
     if ($principal.IsInRole($adminRole)) {
         $prefix = "[ADMIN]:$prefix"
     }

--- a/reference/docs-conceptual/learn/shell/dynamic-help.md
+++ b/reference/docs-conceptual/learn/shell/dynamic-help.md
@@ -52,7 +52,7 @@ To work around these quirks, map the PSReadLine function to an available key com
 example:
 
 ```powershell
-Set-PSReadLineKeyHandler -chord 'Ctrl+l' -Function ShowParameterHelp
+Set-PSReadLineKeyHandler -Chord 'Ctrl+l' -Function ShowParameterHelp
 Set-PSReadLineKeyHandler -Chord 'Ctrl+k' -Function SelectCommandArgument
 ```
 

--- a/reference/docs-conceptual/learn/shell/output-for-screen-reader.md
+++ b/reference/docs-conceptual/learn/shell/output-for-screen-reader.md
@@ -58,7 +58,7 @@ HTML files can be viewed by web browsers such as **Microsoft Edge**. The followi
 to save the output of a command to an HTML file.
 
 ```powershell
-Get-Service | ConvertTo-HTML | Out-File .\myFile.html
+Get-Service | ConvertTo-Html | Out-File .\myFile.html
 Invoke-Item .\myFile.html
 ```
 
@@ -87,7 +87,7 @@ Each of the following commands improves the output in a different way:
 
 ```powershell
 Get-Service -ErrorAction SilentlyContinue |
-    Where-Object {$_.Status -eq 'Running' -and $_.Description -Match 'event'} |
+    Where-Object {$_.Status -eq 'Running' -and $_.Description -match 'event'} |
     Select-Object Name, DisplayName |
     Format-List
 ```

--- a/reference/docs-conceptual/learn/shell/tab-completion.md
+++ b/reference/docs-conceptual/learn/shell/tab-completion.md
@@ -61,7 +61,7 @@ PowerShell 7.2
 - Fix tab completion for unlocalized `about*` topics
 - Fix splatting being treated as positional parameter in completions
 - Add completions for Comment-based Help keywords
-- Add completion for `#requires` statements
+- Add completion for `#Requires` statements
 - Add tab completion for **View** parameter of `Format-*` cmdlets
 - Add support for class-based argument completers
 

--- a/reference/docs-conceptual/learn/shell/using-aliases.md
+++ b/reference/docs-conceptual/learn/shell/using-aliases.md
@@ -68,11 +68,11 @@ Set-Alias -Name cmpo  -Value Compare-Object
 
 ## Compatibility aliases in Windows
 
-PowerShell has several aliases that allow **UNIX** and `cmd.exe` users to use familiar commands in
+PowerShell has several aliases that allow **Unix** and `cmd.exe` users to use familiar commands in
 Windows. The following table show common commands, the related PowerShell cmdlet, and the PowerShell
 alias:
 
-|     Windows Command Shell     | UNIX command | PowerShell cmdlet |             PowerShell alias              |
+|     Windows Command Shell     | Unix command | PowerShell cmdlet |             PowerShell alias              |
 | ----------------------------- | ------------ | ----------------- | ----------------------------------------- |
 | `cd`, `chdir`                 | `cd`         | `Set-Location`    | `sl`, `cd`, `chdir`                       |
 | `cls`                         | `clear`      | `Clear-Host`      | `cls` `clear`                             |
@@ -114,8 +114,8 @@ For more information, see the [Alias attribute][03] documentation.
 In addition to parameter aliases, PowerShell lets you specify the parameter name using the fewest
 characters needed to uniquely identify the parameter. For example, the `Get-ChildItem` cmdlet has
 the **Recurse** and **ReadOnly** parameters. To uniquely identify the **Recurse** parameter you only
-need to provide `-rec`. If you combine that with the command alias, `Get-ChildItem -Recurse` can be
-shortened to `dir -rec`.
+need to provide `-Rec`. If you combine that with the command alias, `Get-ChildItem -Recurse` can be
+shortened to `dir -Rec`.
 
 ## Don't use aliases in scripts
 

--- a/reference/docs-conceptual/samples/Creating-Get-WinEvent-queries-with-FilterHashtable.md
+++ b/reference/docs-conceptual/samples/Creating-Get-WinEvent-queries-with-FilterHashtable.md
@@ -24,7 +24,7 @@ log data. For example, the following commands are inefficient to filter the
 ```powershell
 Get-EventLog -LogName Application | Where-Object Source -Match defrag
 
-Get-WinEvent -LogName Application | Where-Object { $_.ProviderName -Match 'defrag' }
+Get-WinEvent -LogName Application | Where-Object { $_.ProviderName -match 'defrag' }
 ```
 
 The following command uses a hash table that improves the performance:
@@ -55,7 +55,7 @@ If the **key-value** pairs are on the same line, they must be separated by a sem
 places **key-value** pairs on separate lines and doesn't use semicolons.
 
 This sample uses several of the **FilterHashtable** parameter's **key-value** pairs. The completed
-query includes **LogName**, **ProviderName**, **Keywords**, **ID**, and **Level**.
+query includes **LogName**, **ProviderName**, **Keywords**, **Id**, and **Level**.
 
 The accepted **key-value** pairs are shown in the following table and are included in the
 documentation for the [Get-WinEvent][06] **FilterHashtable** parameter.
@@ -216,26 +216,26 @@ Get-WinEvent -FilterHashtable @{
 
 The **Keywords** key is enumerated, but you can use a static property name in the hash table query.
 Rather than using the returned string, the property name must be converted to a value with the
-**Value__** property.
+**value__** property.
 
-For example, the following script uses the **Value__** property.
+For example, the following script uses the **value__** property.
 
 ```powershell
 $C = [System.Diagnostics.Eventing.Reader.StandardEventKeywords]::EventLogClassic
 Get-WinEvent -FilterHashtable @{
    LogName='Application'
    ProviderName='.NET Runtime'
-   Keywords=$C.Value__
+   Keywords=$C.value__
 }
 ```
 
 ## Filtering by Event Id
 
 To get more specific data, the query's results are filtered by **Event Id**. The **Event Id** is
-referenced in the hash table as the key **ID** and the value is a specific **Event Id**. The
+referenced in the hash table as the key **Id** and the value is a specific **Event Id**. The
 **Windows Event Viewer** displays the **Event Id**. This example uses **Event Id 1023**.
 
-Update the hash table and include the **key-value** pair with the key, **ID** and the value,
+Update the hash table and include the **key-value** pair with the key, **Id** and the value,
 **1023**.
 
 ```powershell
@@ -304,9 +304,9 @@ Get-WinEvent -FilterHashtable @{
 
 The **Level** key is enumerated, but you can use a static property name in the hash table query.
 Rather than using the returned string, the property name must be converted to a value with the
-**Value__** property.
+**value__** property.
 
-For example, the following script uses the **Value__** property.
+For example, the following script uses the **value__** property.
 
 ```powershell
 $C = [System.Diagnostics.Eventing.Reader.StandardEventLevel]::Informational
@@ -315,7 +315,7 @@ Get-WinEvent -FilterHashtable @{
    ProviderName='.NET Runtime'
    Keywords=36028797018963968
    ID=1023
-   Level=$C.Value__
+   Level=$C.value__
 }
 ```
 

--- a/reference/docs-conceptual/samples/Creating-a-Custom-Input-Box.md
+++ b/reference/docs-conceptual/samples/Creating-a-Custom-Input-Box.md
@@ -157,7 +157,7 @@ Add the following line of code to display the form in Windows.
 $result = $form.ShowDialog()
 ```
 
-Finally, the code inside the **If** block instructs Windows what to do with the form after users
+Finally, the code inside the `if` block instructs Windows what to do with the form after users
 provide text in the text box, and then click the **OK** button or press the **Enter** key.
 
 ```powershell

--- a/reference/docs-conceptual/samples/Decode-PowerShell-Command-from-a-Running-Process.md
+++ b/reference/docs-conceptual/samples/Decode-PowerShell-Command-from-a-Running-Process.md
@@ -54,8 +54,8 @@ encoded command.
 ```powershell
 $commandDetails = $powerShellProcesses | Select-Object -Property ProcessId,
 @{
-    name       = 'EncodedCommand'
-    expression = {
+    Name       = 'EncodedCommand'
+    Expression = {
         if ( $_.CommandLine -match 'encodedCommand (.*) -inputFormat' )
         {
             return $Matches[1]
@@ -81,7 +81,7 @@ $commandDetails | ForEach-Object -Process {
 
     # Add the decoded command back to the object
     $commandDetails |
-        Where-Object -FilterScript { $_.ProcessId -eq $currentProcess.processId } |
+        Where-Object -FilterScript { $_.ProcessId -eq $currentProcess.ProcessId } |
         Add-Member -MemberType NoteProperty -Name DecodedCommand -Value $decodedCommand
 }
 $commandDetails[0] | Format-List -Property *

--- a/reference/docs-conceptual/samples/Getting-WMI-Objects--Get-CimInstance-.md
+++ b/reference/docs-conceptual/samples/Getting-WMI-Objects--Get-CimInstance-.md
@@ -24,7 +24,7 @@ classes available on the local computer by typing:
 
 ```powershell
 Get-CimClass -Namespace root/CIMV2 | 
-    Where-Object CimClassName -like Win32* | 
+    Where-Object CimClassName -Like Win32* | 
     Select-Object CimClassName
 ```
 
@@ -79,9 +79,10 @@ C:\WINDOWS\system32 Microsoft    22621       USER1          00330-80000-00000-AA
 Although we're showing all of the parameters, the command can be expressed in a more succinct way.
 The **ComputerName** parameter isn't necessary when connecting to the local system. We show it to
 demonstrate the most general case and remind you about the parameter. The **Namespace** defaults to
-`root/CIMV2`, and can be omitted as well. Finally, most cmdlets allow you to omit the name of common
-parameters. With `Get-CimInstance`, if no name is specified for the first parameter, PowerShell
-treats it as the **Class** parameter. This means the last command could have been issued by typing:
+**root/CIMV2**, and can be omitted as well. Finally, most cmdlets allow you to omit the name of
+common parameters. With `Get-CimInstance`, if no name is specified for the first parameter,
+PowerShell treats it as the **Class** parameter. This means the last command could have been issued
+by typing:
 
 ```powershell
 Get-CimInstance Win32_OperatingSystem

--- a/reference/docs-conceptual/samples/Managing-Current-Location.md
+++ b/reference/docs-conceptual/samples/Managing-Current-Location.md
@@ -60,7 +60,7 @@ C:\WINDOWS
 The **PassThru** parameter can be used with many Set commands in PowerShell to return information
 about the result for cases in which there is no default output.
 
-You can specify paths relative to your current location in the same way as you would in most UNIX
+You can specify paths relative to your current location in the same way as you would in most Unix
 and Windows command shells. In standard notation for relative paths, a period (`.`) represents your
 current folder, and a doubled period (`..`) represents the parent directory of your current
 location.

--- a/reference/docs-conceptual/samples/Managing-Processes-with-Process-Cmdlets.md
+++ b/reference/docs-conceptual/samples/Managing-Processes-with-Process-Cmdlets.md
@@ -18,7 +18,7 @@ You can get particular processes by specifying their process names or process ID
 command gets the Idle process:
 
 ```powershell
-Get-Process -id 0
+Get-Process -Id 0
 ```
 
 ```Output
@@ -81,7 +81,7 @@ example, the following command gets the PowerShell processes on the local comput
 "localhost") and on two remote computers.
 
 ```powershell
-Get-Process -Name PowerShell -ComputerName localhost, Server01, Server02
+Get-Process -Name powershell -ComputerName localhost, Server01, Server02
 ```
 
 ```Output
@@ -94,12 +94,12 @@ Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 
 The computer names aren't evident in this display, but they're stored in the **MachineName** property of
 the process objects that `Get-Process` returns. The following command uses the `Format-Table` cmdlet
-to display the process **ID**, **ProcessName** and **MachineName** (ComputerName) properties of the
+to display the process **Id**, **ProcessName** and **MachineName** (ComputerName) properties of the
 process objects.
 
 ```powershell
-Get-Process -Name PowerShell -ComputerName localhost, Server01, Server01 |
-    Format-Table -Property ID, ProcessName, MachineName
+Get-Process -Name powershell -ComputerName localhost, Server01, Server01 |
+    Format-Table -Property Id, ProcessName, MachineName
 ```
 
 ```Output
@@ -120,7 +120,7 @@ Get-Process powershell -ComputerName localhost, Server01, Server02 |
         @{Label="WS(K)";Expression={[int]($_.WS/1024)}},
         @{Label="VM(M)";Expression={[int]($_.VM/1MB)}},
         @{Label="CPU(s)";Expression={if ($_.CPU -ne $()){$_.CPU.ToString("N")}}},
-        Id, ProcessName, MachineName -auto
+        Id, ProcessName, MachineName -Auto
 ```
 
 ```Output
@@ -195,7 +195,7 @@ command on a remote computer, you need to use the `Invoke-Command` cmdlet. For e
 PowerShell process on the Server01 remote computer, type:
 
 ```powershell
-Invoke-Command -ComputerName Server01 {Stop-Process Powershell}
+Invoke-Command -ComputerName Server01 {Stop-Process PowerShell}
 ```
 
 ## Stopping All Other PowerShell Sessions

--- a/reference/docs-conceptual/samples/Managing-Services.md
+++ b/reference/docs-conceptual/samples/Managing-Services.md
@@ -110,7 +110,7 @@ services.
 
 ```powershell
 Get-Service -Name * | Where-Object {$_.RequiredServices -or $_.DependentServices} |
-  Format-Table -Property Status, Name, RequiredServices, DependentServices -auto
+  Format-Table -Property Status, Name, RequiredServices, DependentServices -Auto
 ```
 
 ## Stopping, starting, suspending, and restarting services

--- a/reference/docs-conceptual/samples/Managing-Windows-PowerShell-Drives.md
+++ b/reference/docs-conceptual/samples/Managing-Windows-PowerShell-Drives.md
@@ -178,7 +178,7 @@ cvkey:\
 
 The `New-PSDrive` cmdlet adds the new drive only to the current PowerShell session. If you close the
 PowerShell window, the new drive is lost. To save a PowerShell drive, use the `Export-Console` cmdlet
-to export the current PowerShell session, and then use the `PowerShell.exe` **PSConsoleFile**
+to export the current PowerShell session, and then use the `powershell.exe` **PSConsoleFile**
 parameter to import it. Or, add the new drive to your Windows PowerShell profile.
 
 ## Deleting PowerShell drives
@@ -200,13 +200,13 @@ However, you can't delete it while you are in the drive. For example:
 
 ```powershell
 cd office:
-Remove-PSDrive -Name office
+Remove-PSDrive -Name Office
 ```
 
 ```Output
 Remove-PSDrive : Cannot remove drive 'Office' because it is in use.
 At line:1 char:15
-+ remove-psdrive  <<<< -name office
++ Remove-PSDrive  <<<< -Name Office
 ```
 
 ## Adding and removing drives outside PowerShell

--- a/reference/docs-conceptual/samples/Manipulating-Items-Directly.md
+++ b/reference/docs-conceptual/samples/Manipulating-Items-Directly.md
@@ -33,12 +33,12 @@ Cmdlet          Set-Item                        Set-Item [-Path] <String[]> ...
 ## Creating new items
 
 To create a new item in the filesystem, use the `New-Item` cmdlet. Include the **Path** parameter
-with path to the item, and the **ItemType** parameter with a value of `file` or `directory`.
+with path to the item, and the **ItemType** parameter with a value of `File` or `Directory`.
 
 For example, to create a new directory named `New.Directory` in the `C:\Temp` directory, type:
 
 ```powershell
-New-Item -Path c:\temp\New.Directory -ItemType Directory
+New-Item -Path C:\temp\New.Directory -ItemType Directory
 ```
 
 ```Output
@@ -49,11 +49,11 @@ Mode                LastWriteTime     Length Name
 d----        2006-05-18  11:29 AM            New.Directory
 ```
 
-To create a file, change the value of the **ItemType** parameter to `file`. For example, to create a
+To create a file, change the value of the **ItemType** parameter to `File`. For example, to create a
 file named `file1.txt` in the `New.Directory` directory, type:
 
 ```powershell
-New-Item -Path C:\temp\New.Directory\file1.txt -ItemType file
+New-Item -Path C:\temp\New.Directory\file1.txt -ItemType File
 ```
 
 ```Output
@@ -127,13 +127,13 @@ following command fails because it attempts to move the file from the `New.Direc
 the Temp directory.
 
 ```powershell
-Rename-Item -Path C:\temp\New.Directory\fileOne.txt c:\temp\fileOne.txt
+Rename-Item -Path C:\temp\New.Directory\fileOne.txt C:\temp\fileOne.txt
 ```
 
 ```Output
 Rename-Item : can't rename because the target specified isn't a path.
 At line:1 char:12
-+ Rename-Item  <<<< -Path C:\temp\New.Directory\fileOne c:\temp\fileOne.txt
++ Rename-Item  <<<< -Path C:\temp\New.Directory\fileOne C:\temp\fileOne.txt
 ```
 
 ## Moving items
@@ -217,7 +217,7 @@ Remove-Item C:\temp\New.Directory
 
 ```Output
 Confirm
-The item at C:\temp\New.Directory has children and the -recurse parameter was not
+The item at C:\temp\New.Directory has children and the -Recurse parameter was not
 specified. If you continue, all children will be removed with the item. Are you
  sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help

--- a/reference/docs-conceptual/samples/Performing-Networking-Tasks.md
+++ b/reference/docs-conceptual/samples/Performing-Networking-Tasks.md
@@ -89,12 +89,12 @@ Get-CimInstance -Class Win32_PingStatus -Filter "Address='127.0.0.1'"
 ```
 
 The response from **Win32_PingStatus** contains 29 properties. You can use `Format-Table` to select
-the properties that are most interesting to you. The **Autosize** parameter of `Format-Table`
+the properties that are most interesting to you. The **AutoSize** parameter of `Format-Table`
 resizes the table columns so that they display properly in PowerShell.
 
 ```powershell
 Get-CimInstance -Class Win32_PingStatus -Filter "Address='127.0.0.1'" |
-    Format-Table -Property Address,ResponseTime,StatusCode -Autosize
+    Format-Table -Property Address,ResponseTime,StatusCode -AutoSize
 ```
 
 ```Output
@@ -268,7 +268,7 @@ Invoke-CimMethod -ClassName Win32_Share -MethodName Create -Arguments @{
 This is equivalent to the following `net share` command on Windows:
 
 ```powershell
-net share tempshare=c:\temp /users:25 /remark:"test share of the temp folder"
+net share tempshare=C:\temp /users:25 /remark:"test share of the temp folder"
 ```
 
 To call a method of a WMI class that takes parameters you must know what parameters are available

--- a/reference/docs-conceptual/samples/Redirecting-Data-with-Out---Cmdlets.md
+++ b/reference/docs-conceptual/samples/Redirecting-Data-with-Out---Cmdlets.md
@@ -139,15 +139,15 @@ ASCII files, don't work correctly with the default output format. You can change
 format to ASCII using the **Encoding** parameter:
 
 ```powershell
-Get-Process | Out-File -FilePath C:\temp\processlist.txt -Encoding ASCII
+Get-Process | Out-File -FilePath C:\temp\processlist.txt -Encoding ascii
 ```
 
-`Out-file` formats file contents to look like console output. This causes the output to be truncated
+`Out-File` formats file contents to look like console output. This causes the output to be truncated
 just as it's in a console window in most circumstances. For example, if you run the following
 command:
 
 ```powershell
-Get-Command | Out-File -FilePath c:\temp\output.txt
+Get-Command | Out-File -FilePath C:\temp\output.txt
 ```
 
 The output will look like this:
@@ -165,7 +165,7 @@ parameter to specify line width. Because **Width** is a 32-bit integer parameter
 it can have is 2147483647. Type the following to set the line width to this maximum value:
 
 ```powershell
-Get-Command | Out-File -FilePath c:\temp\output.txt -Width 2147483647
+Get-Command | Out-File -FilePath C:\temp\output.txt -Width 2147483647
 ```
 
 The `Out-File` cmdlet is most useful when you want to save output as it would have displayed on the

--- a/reference/docs-conceptual/samples/Selecting-Items-from-a-List-Box.md
+++ b/reference/docs-conceptual/samples/Selecting-Items-from-a-List-Box.md
@@ -180,7 +180,7 @@ Add the following line of code to display the form in Windows.
 $result = $form.ShowDialog()
 ```
 
-Finally, the code inside the **If** block instructs Windows what to do with the form after users
+Finally, the code inside the `if` block instructs Windows what to do with the form after users
 select an option from the list box, and then click the **OK** button or press the **Enter** key.
 
 ```powershell

--- a/reference/docs-conceptual/samples/Selecting-Parts-of-Objects--Select-Object-.md
+++ b/reference/docs-conceptual/samples/Selecting-Parts-of-Objects--Select-Object-.md
@@ -27,8 +27,8 @@ rather than bytes.
 ```powershell
 Get-CimInstance -Class Win32_LogicalDisk |
     Select-Object -Property Name, @{
-        label='FreeSpace'
-        expression={($_.FreeSpace/1GB).ToString('F2')}
+        Label='FreeSpace'
+        Expression={($_.FreeSpace/1GB).ToString('F2')}
     }
 ```
 

--- a/reference/docs-conceptual/samples/Using-Format-Commands-to-Change-Output-View.md
+++ b/reference/docs-conceptual/samples/Using-Format-Commands-to-Change-Output-View.md
@@ -28,8 +28,8 @@ This article describes the `Format-Wide`, `Format-List`, and `Format-Table` cmdl
 Each object type in PowerShell has default properties that are used when you don't select the
 properties to display. Each cmdlet uses the same **Property** parameter to specify which properties
 you want displayed. Because `Format-Wide` only shows a single property, its **Property** parameter
-only takes a single value, but the property parameters of `Format-List` and `Format-Table` accept a
-list of property names.
+only takes a single value, but the **Property** parameter of `Format-List` and `Format-Table`
+accepts a list of property names.
 
 In this example, the default output of `Get-Process` cmdlet shows that we've two instances of
 Internet Explorer running.

--- a/reference/docs-conceptual/samples/Using-Static-Classes-and-Methods.md
+++ b/reference/docs-conceptual/samples/Using-Static-Classes-and-Methods.md
@@ -121,14 +121,14 @@ method or property. To see the command that was used to launch Windows PowerShel
 **CommandLine** property by typing:
 
 ```powershell
-[System.Environment]::Commandline
+[System.Environment]::CommandLine
 ```
 
 ```Output
 "C:\Program Files\Windows PowerShell\v1.0\powershell.exe"
 ```
 
-To check the operating system version, display the OSVersion property by typing:
+To check the operating system version, display the **OSVersion** property by typing:
 
 ```powershell
 [System.Environment]::OSVersion

--- a/reference/docs-conceptual/samples/Working-With-Files-Folders-and-Registry-Keys.md
+++ b/reference/docs-conceptual/samples/Working-With-Files-Folders-and-Registry-Keys.md
@@ -34,7 +34,7 @@ Mode                LastWriteTime     Length Name
 ```
 
 The listing looks similar to what you would see when you enter the `dir` command in `cmd.exe`, or
-the `ls` command in a UNIX command shell.
+the `ls` command in a Unix command shell.
 
 You can perform complex listings using parameters of the `Get-ChildItem` cmdlet. You can see the
 syntax the `Get-ChildItem` cmdlet by typing:
@@ -64,7 +64,7 @@ Mode                LastWriteTime     Length Name
 
 ### Filtering items by name
 
-To display only the names of items, use the **Name** parameter of `Get-Childitem`:
+To display only the names of items, use the **Name** parameter of `Get-ChildItem`:
 
 ```
 PS> Get-ChildItem -Path C:\WINDOWS -Name

--- a/reference/docs-conceptual/samples/Working-with-Files-and-Folders.md
+++ b/reference/docs-conceptual/samples/Working-with-Files-and-Folders.md
@@ -20,7 +20,7 @@ Get-ChildItem -Path C:\ -Force
 ```
 
 The command lists only the directly contained items, much like using the `dir` command in `cmd.exe`
-or `ls` in a UNIX shell. To show items in subfolder, you need to specify the **Recurse** parameter.
+or `ls` in a Unix shell. To show items in subfolder, you need to specify the **Recurse** parameter.
 The following command lists everything on the `C:` drive:
 
 ```powershell
@@ -35,7 +35,7 @@ The following command finds all executables within the Program Files folder that
 after October 1, 2005 and that are neither smaller than 1 megabyte nor larger than 10 megabytes:
 
 ```powershell
-Get-ChildItem -Path $env:ProgramFiles -Recurse -Include *.exe |
+Get-ChildItem -Path $Env:ProgramFiles -Recurse -Include *.exe |
     Where-Object -FilterScript {
         ($_.LastWriteTime -gt '2005-10-01') -and ($_.Length -ge 1mb) -and ($_.Length -le 10mb)
     }
@@ -75,7 +75,7 @@ You can also copy a selection of items. The following command copies all `.txt` 
 anywhere in `C:\data` to `C:\temp\text`:
 
 ```powershell
-Copy-Item -Filter *.txt -Path c:\data -Recurse -Destination C:\temp\text
+Copy-Item -Filter *.txt -Path C:\data -Recurse -Destination C:\temp\text
 ```
 
 You can still run native commands like `xcopy.exe` and `robocopy.exe` to copy files.
@@ -137,7 +137,7 @@ local drive `P:` rooted in the local Program Files directory, visible only from 
 session:
 
 ```powershell
-New-PSDrive -Name P -Root $env:ProgramFiles -PSProvider FileSystem
+New-PSDrive -Name P -Root $Env:ProgramFiles -PSProvider FileSystem
 ```
 
 Just as with network drives, drives mapped within PowerShell are immediately visible to the

--- a/reference/docs-conceptual/samples/Working-with-Registry-Keys.md
+++ b/reference/docs-conceptual/samples/Working-with-Registry-Keys.md
@@ -50,8 +50,8 @@ HKEY_CURRENT_USER\Volatile Environment
 These are the top-level keys visible under `HKEY_CURRENT_USER` in the Registry Editor
 (`regedit.exe`).
 
-You can also specify this registry path by specifying the registry provider's name, followed by
-`::`. The registry provider's full name is `Microsoft.PowerShell.Core\Registry`, but this can be
+You can also specify this registry path by specifying the Registry provider's name, followed by
+`::`. The Registry provider's full name is `Microsoft.PowerShell.Core\Registry`, but this can be
 shortened to just `Registry`. Any of the following commands will list the contents directly under
 `HKCU:`.
 
@@ -64,7 +64,7 @@ Get-ChildItem HKCU:
 ```
 
 These commands list only the directly contained items, much like using `DIR` in `cmd.exe` or `ls`
-in a UNIX shell. To show contained items, you need to specify the **Recurse** parameter. To list all
+in a Unix shell. To show contained items, you need to specify the **Recurse** parameter. To list all
 registry keys in `HKCU:`, use the following command.
 
 ```powershell
@@ -143,7 +143,7 @@ Remove-Item -Path HKCU:\CurrentVersion
 
 ```Output
 Confirm
-The item at HKCU:\CurrentVersion\AdminDebug has children and the -recurse
+The item at HKCU:\CurrentVersion\AdminDebug has children and the Recurse
 parameter was not specified. If you continue, all children will be removed with
 the item. Are you sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide