### PR TITLE
Fixes description of __AllParameterSets and ValueFromPipeline in about_Parameter_Sets

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -69,11 +69,11 @@ handling.
 default name is not used.
 
 Setting the `ParameterSetName` of a the **Parameter** attribute to
-`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
-cases the parameter belongs to all parameter sets.
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In
+both cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> The **CmdletBinding** attribute doesn't prevent you from setting the
 > `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
 > PowerShell creates an explicit parameter set that can't be properly
 > referenced by the **Parameter** attribute.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -33,10 +33,6 @@ The following requirements apply to all parameter sets.
   unique positions for each parameter. No two positional parameters can specify
   the same position.
 
-- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
-  a value of `true`. Multiple parameters can define the
-  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
-
 > [!NOTE]
 > There is a limit of 32 parameter sets.
 
@@ -69,12 +65,20 @@ parameter sets.
 PowerShell reserves the parameter set name `__AllParameterSets` for special
 handling.
 
-- This name is the default name of the parameter set that when you don't
-  explicitly define a parameter set name.
-- When you have muliple parameter sets, you can use this name to define a
-  parameter that belongs to all parameter sets.
-- Setting **DefaultParameterSetName** to `__AllParameterSets` in the
-  `[CmdletBinding()]` attribute has no effect.
+`__AllParameterSets` is the name of the default parameter set when an explicit
+default name is not used.
+
+Setting the `ParameterSetName` of a the **Parameter** attribute to
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
+cases the parameter belongs to all parameter sets.
+
+> [!NOTE]
+> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
+
+The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
+explicitly set to `__AllParameterSets`. This is not recommended as it causes
+creation of an explicit parameter set which cannot be properly referenced by the
+**Parameter** attribute.
 
 ## Examples
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -73,12 +73,10 @@ Setting the `ParameterSetName` of a the **Parameter** attribute to
 cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
-
-The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
-explicitly set to `__AllParameterSets`. This is not recommended as it causes
-creation of an explicit parameter set which cannot be properly referenced by the
-**Parameter** attribute.
+> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
+> PowerShell creates an explicit parameter set that can't be properly
+> referenced by the **Parameter** attribute.
 
 ## Examples
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -69,11 +69,11 @@ handling.
 default name is not used.
 
 Setting the `ParameterSetName` of a the **Parameter** attribute to
-`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
-cases the parameter belongs to all parameter sets.
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In
+both cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> The **CmdletBinding** attribute doesn't prevent you from setting the
 > `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
 > PowerShell creates an explicit parameter set that can't be properly
 > referenced by the **Parameter** attribute.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -33,10 +33,6 @@ The following requirements apply to all parameter sets.
   unique positions for each parameter. No two positional parameters can specify
   the same position.
 
-- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
-  a value of `true`. Multiple parameters can define the
-  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
-
 > [!NOTE]
 > There is a limit of 32 parameter sets.
 
@@ -69,12 +65,20 @@ parameter sets.
 PowerShell reserves the parameter set name `__AllParameterSets` for special
 handling.
 
-- This name is the default name of the parameter set that when you don't
-  explicitly define a parameter set name.
-- When you have muliple parameter sets, you can use this name to define a
-  parameter that belongs to all parameter sets.
-- Setting **DefaultParameterSetName** to `__AllParameterSets` in the
-  `[CmdletBinding()]` attribute has no effect.
+`__AllParameterSets` is the name of the default parameter set when an explicit
+default name is not used.
+
+Setting the `ParameterSetName` of a the **Parameter** attribute to
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
+cases the parameter belongs to all parameter sets.
+
+> [!NOTE]
+> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
+
+The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
+explicitly set to `__AllParameterSets`. This is not recommended as it causes
+creation of an explicit parameter set which cannot be properly referenced by the
+**Parameter** attribute.
 
 ## Examples
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -73,12 +73,10 @@ Setting the `ParameterSetName` of a the **Parameter** attribute to
 cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
-
-The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
-explicitly set to `__AllParameterSets`. This is not recommended as it causes
-creation of an explicit parameter set which cannot be properly referenced by the
-**Parameter** attribute.
+> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
+> PowerShell creates an explicit parameter set that can't be properly
+> referenced by the **Parameter** attribute.
 
 ## Examples
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -69,11 +69,11 @@ handling.
 default name is not used.
 
 Setting the `ParameterSetName` of a the **Parameter** attribute to
-`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
-cases the parameter belongs to all parameter sets.
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In
+both cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> The **CmdletBinding** attribute doesn't prevent you from setting the
 > `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
 > PowerShell creates an explicit parameter set that can't be properly
 > referenced by the **Parameter** attribute.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -33,10 +33,6 @@ The following requirements apply to all parameter sets.
   unique positions for each parameter. No two positional parameters can specify
   the same position.
 
-- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
-  a value of `true`. Multiple parameters can define the
-  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
-
 > [!NOTE]
 > There is a limit of 32 parameter sets.
 
@@ -69,12 +65,20 @@ parameter sets.
 PowerShell reserves the parameter set name `__AllParameterSets` for special
 handling.
 
-- This name is the default name of the parameter set that when you don't
-  explicitly define a parameter set name.
-- When you have muliple parameter sets, you can use this name to define a
-  parameter that belongs to all parameter sets.
-- Setting **DefaultParameterSetName** to `__AllParameterSets` in the
-  `[CmdletBinding()]` attribute has no effect.
+`__AllParameterSets` is the name of the default parameter set when an explicit
+default name is not used.
+
+Setting the `ParameterSetName` of a the **Parameter** attribute to
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
+cases the parameter belongs to all parameter sets.
+
+> [!NOTE]
+> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
+
+The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
+explicitly set to `__AllParameterSets`. This is not recommended as it causes
+creation of an explicit parameter set which cannot be properly referenced by the
+**Parameter** attribute.
 
 ## Examples
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -73,12 +73,10 @@ Setting the `ParameterSetName` of a the **Parameter** attribute to
 cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
-
-The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
-explicitly set to `__AllParameterSets`. This is not recommended as it causes
-creation of an explicit parameter set which cannot be properly referenced by the
-**Parameter** attribute.
+> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
+> PowerShell creates an explicit parameter set that can't be properly
+> referenced by the **Parameter** attribute.
 
 ## Examples
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -69,11 +69,11 @@ handling.
 default name is not used.
 
 Setting the `ParameterSetName` of a the **Parameter** attribute to
-`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
-cases the parameter belongs to all parameter sets.
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In
+both cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> The **CmdletBinding** attribute doesn't prevent you from setting the
 > `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
 > PowerShell creates an explicit parameter set that can't be properly
 > referenced by the **Parameter** attribute.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -33,10 +33,6 @@ The following requirements apply to all parameter sets.
   unique positions for each parameter. No two positional parameters can specify
   the same position.
 
-- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
-  a value of `true`. Multiple parameters can define the
-  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
-
 > [!NOTE]
 > There is a limit of 32 parameter sets.
 
@@ -69,12 +65,20 @@ parameter sets.
 PowerShell reserves the parameter set name `__AllParameterSets` for special
 handling.
 
-- This name is the default name of the parameter set that when you don't
-  explicitly define a parameter set name.
-- When you have muliple parameter sets, you can use this name to define a
-  parameter that belongs to all parameter sets.
-- Setting **DefaultParameterSetName** to `__AllParameterSets` in the
-  `[CmdletBinding()]` attribute has no effect.
+`__AllParameterSets` is the name of the default parameter set when an explicit
+default name is not used.
+
+Setting the `ParameterSetName` of a the **Parameter** attribute to
+`__AllParameterSets` is equivalent to not assigning a `ParameterSetName`. In both
+cases the parameter belongs to all parameter sets.
+
+> [!NOTE]
+> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
+
+The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
+explicitly set to `__AllParameterSets`. This is not recommended as it causes
+creation of an explicit parameter set which cannot be properly referenced by the
+**Parameter** attribute.
 
 ## Examples
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -73,12 +73,10 @@ Setting the `ParameterSetName` of a the **Parameter** attribute to
 cases the parameter belongs to all parameter sets.
 
 > [!NOTE]
-> `DefaultParameterSetName` should not be explicitly set to `__AllParameterSets`.
-
-The **CmdletBinding** attribute allows the `DefaultParameterSetName` to be
-explicitly set to `__AllParameterSets`. This is not recommended as it causes
-creation of an explicit parameter set which cannot be properly referenced by the
-**Parameter** attribute.
+> The **CmdletBinding** attribute doesn't prevent you from setting the 
+> `DefaultParameterSetName` to be to `__AllParameterSets`. If you do this,
+> PowerShell creates an explicit parameter set that can't be properly
+> referenced by the **Parameter** attribute.
 
 ## Examples
 


### PR DESCRIPTION
# PR Summary

- Updates content from #11956.
- Revisits fix for #11955

In addition to the changes above, I have also deleted this fragment:
```
- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
  a value of `true`. Multiple parameters can define the
  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
```
It's simply not true. You can define more than one by-value parameter, and you can fill more than one by-value parameter in the same set. I saw no reason to replace it in this about, it's not really related to parameter sets (imo).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
