### PR TITLE
Update `ForEach-Object` example 17 to reflect current behavior

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/26/2024
+ms.date: 04/13/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -457,23 +457,10 @@ Output: 5
 
 ### Example 17: Passing variables in nested parallel scriptblocks
 
-You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use
-it inside the scriptblock with the `Using:` scope modifier.
-
-```powershell
-$test1 = 'TestA'
-1..2 | ForEach-Object -Parallel {
-    $Using:test1
-}
-```
-
-```Output
-TestA
-TestA
-```
-
-Beginning in PowerShell 7.2, you can create a variable inside a `ForEach-Object -Parallel` scoped
-scriptblock and use it inside a nested scriptblock.
+You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use it inside
+the scriptblock with the `Using:` scope modifier. Beginning in PowerShell 7.2, you can create a
+variable inside a `ForEach-Object -Parallel` scoped scriptblock and use it inside a nested
+scriptblock.
 
 ```powershell
 $test1 = 'TestA'

--- a/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -455,7 +455,7 @@ Output: 5
 > [PipelineVariable](About/about_CommonParameters.md) common parameter variables are _not_
 > supported in `ForEach-Object -Parallel` scenarios even with the `Using:` scope modifier.
 
-### Example 17: Passing variables in nested parallel script ScriptBlockSet
+### Example 17: Passing variables in nested parallel scriptblocks
 
 You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use
 it inside the scriptblock with the `Using:` scope modifier.
@@ -472,9 +472,10 @@ TestA
 TestA
 ```
 
+Beginning in PowerShell 7.2, you can create a variable inside a `ForEach-Object -Parallel` scoped
+scriptblock and use it inside a nested scriptblock.
+
 ```powershell
-# You CANNOT create a variable inside a scoped scriptblock
-# to be used in a nested foreach parallel scriptblock.
 $test1 = 'TestA'
 1..2 | ForEach-Object -Parallel {
     $Using:test1
@@ -486,14 +487,17 @@ $test1 = 'TestA'
 ```
 
 ```Output
-Line |
-   2 |  1..2 | ForEach-Object -Parallel {
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
-     | The value of the using variable '$Using:test2' can't be retrieved because it has
-     | not been set in the local session.
+TestA
+TestA
+TestB
+TestB
+TestB
+TestB
 ```
 
-The nested scriptblock can't access the `$test2` variable and an error is thrown.
+> [!NOTE]
+> In versions prior to PowerShell 7.2, the nested scriptblock can't access the `$test2` variable and
+> an error is thrown.
 
 ### Example 18: Creating multiple jobs that run scripts in parallel
 

--- a/reference/7.5/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/26/2024
+ms.date: 04/13/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -457,23 +457,10 @@ Output: 5
 
 ### Example 17: Passing variables in nested parallel scriptblocks
 
-You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use
-it inside the scriptblock with the `Using:` scope modifier.
-
-```powershell
-$test1 = 'TestA'
-1..2 | ForEach-Object -Parallel {
-    $Using:test1
-}
-```
-
-```Output
-TestA
-TestA
-```
-
-Beginning in PowerShell 7.2, you can create a variable inside a `ForEach-Object -Parallel` scoped
-scriptblock and use it inside a nested scriptblock.
+You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use it inside
+the scriptblock with the `Using:` scope modifier. Beginning in PowerShell 7.2, you can create a
+variable inside a `ForEach-Object -Parallel` scoped scriptblock and use it inside a nested
+scriptblock.
 
 ```powershell
 $test1 = 'TestA'

--- a/reference/7.5/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -455,7 +455,7 @@ Output: 5
 > [PipelineVariable](About/about_CommonParameters.md) common parameter variables are _not_
 > supported in `ForEach-Object -Parallel` scenarios even with the `Using:` scope modifier.
 
-### Example 17: Passing variables in nested parallel script ScriptBlockSet
+### Example 17: Passing variables in nested parallel scriptblocks
 
 You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use
 it inside the scriptblock with the `Using:` scope modifier.
@@ -472,9 +472,10 @@ TestA
 TestA
 ```
 
+Beginning in PowerShell 7.2, you can create a variable inside a `ForEach-Object -Parallel` scoped
+scriptblock and use it inside a nested scriptblock.
+
 ```powershell
-# You CANNOT create a variable inside a scoped scriptblock
-# to be used in a nested foreach parallel scriptblock.
 $test1 = 'TestA'
 1..2 | ForEach-Object -Parallel {
     $Using:test1
@@ -486,14 +487,17 @@ $test1 = 'TestA'
 ```
 
 ```Output
-Line |
-   2 |  1..2 | ForEach-Object -Parallel {
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
-     | The value of the using variable '$Using:test2' can't be retrieved because it has
-     | not been set in the local session.
+TestA
+TestA
+TestB
+TestB
+TestB
+TestB
 ```
 
-The nested scriptblock can't access the `$test2` variable and an error is thrown.
+> [!NOTE]
+> In versions prior to PowerShell 7.2, the nested scriptblock can't access the `$test2` variable and
+> an error is thrown.
 
 ### Example 18: Creating multiple jobs that run scripts in parallel
 

--- a/reference/7.6/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -455,7 +455,7 @@ Output: 5
 > [PipelineVariable](About/about_CommonParameters.md) common parameter variables are _not_
 > supported in `ForEach-Object -Parallel` scenarios even with the `Using:` scope modifier.
 
-### Example 17: Passing variables in nested parallel script ScriptBlockSet
+### Example 17: Passing variables in nested parallel scriptblocks
 
 You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use
 it inside the scriptblock with the `Using:` scope modifier.
@@ -472,9 +472,10 @@ TestA
 TestA
 ```
 
+Beginning in PowerShell 7.2, you can create a variable inside a `ForEach-Object -Parallel` scoped
+scriptblock and use it inside a nested scriptblock.
+
 ```powershell
-# You CANNOT create a variable inside a scoped scriptblock
-# to be used in a nested foreach parallel scriptblock.
 $test1 = 'TestA'
 1..2 | ForEach-Object -Parallel {
     $Using:test1
@@ -486,14 +487,17 @@ $test1 = 'TestA'
 ```
 
 ```Output
-Line |
-   2 |  1..2 | ForEach-Object -Parallel {
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
-     | The value of the using variable '$Using:test2' can't be retrieved because it has
-     | not been set in the local session.
+TestA
+TestA
+TestB
+TestB
+TestB
+TestB
 ```
 
-The nested scriptblock can't access the `$test2` variable and an error is thrown.
+> [!NOTE]
+> In versions prior to PowerShell 7.2, the nested scriptblock can't access the `$test2` variable and
+> an error is thrown.
 
 ### Example 18: Creating multiple jobs that run scripts in parallel
 

--- a/reference/7.6/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/26/2024
+ms.date: 04/13/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -457,23 +457,10 @@ Output: 5
 
 ### Example 17: Passing variables in nested parallel scriptblocks
 
-You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use
-it inside the scriptblock with the `Using:` scope modifier.
-
-```powershell
-$test1 = 'TestA'
-1..2 | ForEach-Object -Parallel {
-    $Using:test1
-}
-```
-
-```Output
-TestA
-TestA
-```
-
-Beginning in PowerShell 7.2, you can create a variable inside a `ForEach-Object -Parallel` scoped
-scriptblock and use it inside a nested scriptblock.
+You can create a variable outside a `ForEach-Object -Parallel` scoped scriptblock and use it inside
+the scriptblock with the `Using:` scope modifier. Beginning in PowerShell 7.2, you can create a
+variable inside a `ForEach-Object -Parallel` scoped scriptblock and use it inside a nested
+scriptblock.
 
 ```powershell
 $test1 = 'TestA'


### PR DESCRIPTION
# PR Summary

In this PR, `ForEach-Object` [example 17](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/foreach-object#example-17-passing-variables-in-nested-parallel-script-scriptblockset) is updated to reflect behavior consistent with PS v7.2+. Example 17 demonstrates use of variable access using nested `-Parallel` script blocks.

## PR Context

In PS v7.2, `ForEach-Object -Parallel` was updated to correctly support variable access in nested script block scenarios. See:

- https://github.com/PowerShell/PowerShell/issues/11817
- https://github.com/PowerShell/PowerShell/pull/14548
- [7.2 Changelog](https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/7.2.md#720-preview3---2021-02-11)

Example 17 in the docs currently reflects the erroneous behavior exhibited in v7.1 and prior. This example was added as part of:

- https://github.com/MicrosoftDocs/PowerShell-Docs/pull/7270

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide