### PR TITLE
(GH-12177) Fix `Start-Sleep` example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/22/2023
+ms.date: 06/25/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/start-sleep?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Sleep
@@ -35,12 +35,12 @@ repeating an operation.
 
 ## EXAMPLES
 
-### Example 1: Pause execution for 1.5 seconds
+### Example 1: Pause execution for 1 second
 
-In this example, the execution of commands pauses for one and one-half seconds.
+In this example, the execution of commands pauses for one second.
 
 ```powershell
-Start-Sleep -Seconds 1.5
+Start-Sleep -Seconds 1
 ```
 
 ### Example 2: Pause execution at the command line


### PR DESCRIPTION
# PR Summary

Prior to this change, the example for `Start-Sleep` in Windows PowerShell showed defining the value of the `-Second` parameter as a non-integer. In Windows
PowerShell, the cmdlet only accepts integers.

This change updates the example to show using an
integer instead of a fractional number of seconds.

- Fixes #12177

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
