### PR TITLE
(GHA) Update the auth action to accept an allowlist

### DIFF
--- a/.github/actions/verification/authorization/v1/Parameters.psd1
+++ b/.github/actions/verification/authorization/v1/Parameters.psd1
@@ -29,6 +29,25 @@
         return $Parameters
       }
     }
+    @{
+      Name = 'AuthorizedAccounts'
+      Type = 'String[]'
+      IfNullOrEmpty = {
+          param($ErrorTarget)
+
+          # This parameter is optional, so don't error.
+      }
+      Process = {
+        param($Parameters, $Value, $ErrorTarget)
+
+        [string[]]$SpecifiedAccounts = $Value -split ','
+        if ($SpecifiedAccounts.Count -gt 0) {
+          $Parameters.AuthorizedAccounts = $SpecifiedAccounts
+          Write-HostParameter -Name AuthorizedAccounts -Value $Parameters.AuthorizedAccounts
+        }
+        return $Parameters
+      }
+    }
 
     @{
       Name = 'Permissions'

--- a/.github/actions/verification/authorization/v1/action.yml
+++ b/.github/actions/verification/authorization/v1/action.yml
@@ -4,6 +4,16 @@ description: |
   branch of a repository or to submit a PR editing repo configuration.
 author: PowerShell Docs Team
 inputs:
+  authorized_accounts:
+    description: |
+      Defines one or more authorized accounts to skip permission-checking for. This is best used
+      for bot accounts, which may not have specific permissions to a repository but are used by
+      the organization's automation. Must be a comma-separated string of account names.
+
+      If a user is in the authorized accounts list, the action skips checking permissions and
+      passes for that user.
+    required: false
+    default: ''
   permissions:
     description: |
       The permissions a user requires to perform a given task. Must be a comma-separated string of
@@ -84,6 +94,7 @@ runs:
         INPUT_PERMISSIONS: ${{ inputs.permissions }}
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_USER: ${{ inputs.user }}
+        INPUT_AUTHORIZED_ACCOUNTS: ${{ inputs.authorized_accounts }}
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         Write-Output "::group::Generic Setup"

--- a/.github/actions/verification/authorization/v1/readme.md
+++ b/.github/actions/verification/authorization/v1/readme.md
@@ -54,6 +54,7 @@ jobs:
         uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/authorization/v1@main
         with:
           token: ${{ github.token }}
+          authorized_accounts: 'learn-build-service-prod[bot]'
 ```
 
 This workflow uses the `pull_request_target` trigger to check whether a Pull Request author is
@@ -61,7 +62,10 @@ permitted to submit their Pull Request to the `live` branch. It only runs on Pul
 target the `live` branch, so other Pull Requests don't get a skipped message for this check.
 
 It passes the GitHub token to the action but does not specify a target, relying on the default for
-that input, which is the `live` branch.
+that input, which is the `live` branch. It does specify that the `learn-build-service-prod[bot]`
+managed account is authorized with the `authorized_accounts` parameter. If the account creating a
+PR to the `live` branch is the managed account or has either the `Maintain` or `Admin` permission,
+the workflow will pass.
 
 ### Verifying authorization to change sensitive files
 
@@ -103,6 +107,21 @@ needed to be specified as a comma-separated string. Finally, it specifies the **
 authorization to change files in those paths.
 
 ## Inputs
+
+### `authorized_accounts`
+
+Defines one or more authorized accounts to skip permission-checking for. This is best used for bot
+accounts, which may not have specific permissions to a repository but are used by the
+organization's automation. Must be a comma-separated string of account names.
+
+If a user is in the authorized accounts list, the action skips checking permissions and passes for
+that user.
+
+```yaml
+required : false
+type     : string
+default  : ''
+```
 
 ### `permissions`
 

--- a/.github/workflows/targeting-valid-branch.yml
+++ b/.github/workflows/targeting-valid-branch.yml
@@ -23,3 +23,4 @@ jobs:
         uses: ./.github/actions/verification/authorization/v1
         with:
           token: ${{ github.token }}
+          authorized_accounts: learn-build-service-prod[bot]


### PR DESCRIPTION
# PR Summary

Prior to this change, the verification/`authorization` GitHub Action only supported checking the assigned permissions for a user. This worked for normal accounts. However, the managed bot account for the Learn platform doesn't have permissions for this repository.

This change adds a new (backwards-compatible) `authorized_accounts` parameter to the GHA. Repository maintainers can now define an allowlist to use for authorization in addition to the permissions to check. If a user is explicitly in the allowlist, the action skips checking their permissions. If a user isn't in the allowlist, they can still pass authorization if they have matching permissions.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
