### PR TITLE
Add docs for new .NET MethodInvocation tracing

### DIFF
--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to use methods to perform actions on objects in PowerShell.
 Locale: en-US
-ms.date: 03/16/2022
+ms.date: 10/21/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_methods?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Methods
@@ -257,44 +257,57 @@ specific overload of the **Bar** method.
 int: 1
 ```
 
-## Finding what overload was used
+## Finding which overload was used
 
-Since PowerShell 7.6, it is now possible to see what method overload was chosen
-by PowerShell. This is achieved through the new `MethodInvocation` tracing
-command.
+Beginning in PowerShell 7.6, you can see which method overload PowerShell chose
+by using `MethodInvocation` tracing.
 
-This example shows how to use `Trace-Command` to display the overload chosen
-when calling the [String.Split method](/dotnet/api/system.string.split).
+The following examples use `Trace-Command` to display the overload chosen when
+calling the [String.Split method](xref:System.String.Split%2A).
 
 ```powershell
 Trace-Command -PSHost -Name MethodInvocation -Expression {
     "a 1 b 1 c 1 d".Split(1)
 }
+```
 
+In the first example, the integer `1` was converted to a `[char]` instead of a
+`[string]`, which results in string being split by `[char]1` instead of the
+string `"1"`.
+
+```Output
+DEBUG: ... MethodInvocation Information: 0 : Invoking method: string[] Spli
+t(char separator, System.StringSplitOptions options = System.StringSplitOpt
+ions.None)
+
+a 1 b 1 c 1 d
+```
+
+In the second example, the `Split()` method is called with the string `"1"`.
+
+```powershell
 Trace-Command -PSHost -Name MethodInvocation -Expression {
     "a 1 b 1 c 1 d".Split("1")
 }
 ```
 
+PowerShell chose the overload that takes a `[string]` separator.
+
 ```Output
-DEBUG: ... MethodInvocation Information: 0 : Invoking method: string[] Split(char separator, System.StringSplitOptions options = System.StringSplitOptions.None)
+DEBUG: ... MethodInvocation Information: 0 : Invoking method: string[] Spli
+t(string separator, System.StringSplitOptions options = System.StringSplitO
+ptions.None)
 
-a 1 b 1 c 1 d
-
-DEBUG: ... MethodInvocation Information: 0 : Invoking method: string[] Split(string separator, System.StringSplitOptions options = System.StringSplitOptions.None)
 a
  b
  c
  d
 ```
 
-In the first example the `1` was casted as a `[char]` and not a string causing
-the split output to split by `[char]1` and not the character `"1"`.
-
 ## Using .NET methods that take filesystem paths
 
 PowerShell supports multiple runspaces per process. Each runspace has its own
-_current directory_. This is not the same as the working directory of the
+_current directory_. This isn't the same as the working directory of the
 current process: `[System.Environment]::CurrentDirectory`.
 
 .NET methods use the process working directory. PowerShell cmdlets use the


### PR DESCRIPTION
# PR Summary
Adds docs around the new .NET MethodInvocation tracing call introduced in PowerShell 7.6. This new tracing method allows you to see what method overload was invoked inside the tracing context.

- Added by https://github.com/PowerShell/PowerShell/pull/21320

## PR Checklist
- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].