### PR TITLE
(GHA) Update casing and fix authorization

### DIFF
--- a/.github/actions/commenting/expectations/v1/Parameters.psd1
+++ b/.github/actions/commenting/expectations/v1/Parameters.psd1
@@ -1,7 +1,7 @@
 @{
     Parameters = @(
       @{
-        Name = 'Repository'
+        Name = 'repository'
         Type = 'string'
         IfNullOrEmpty = {
           param($ErrorTarget)
@@ -31,7 +31,7 @@
       }
 
       @{
-        Name = 'Message_Body'
+        Name = 'message_body'
         Type = 'String'
         IfNullOrEmpty = {
           param($ErrorTarget)
@@ -75,7 +75,7 @@
       }
 
       @{
-        Name = 'Message_Path'
+        Name = 'message_path'
         Type = 'String'
         IfNullOrEmpty = {
           param($ErrorTarget)

--- a/.github/actions/reporting/stale-content/v1/Parameters.psd1
+++ b/.github/actions/reporting/stale-content/v1/Parameters.psd1
@@ -1,7 +1,7 @@
 @{
   Parameters = @(
     @{
-      Name = 'Relative_Folder_Path'
+      Name = 'relative_folder_path'
       Type = 'String[]'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -33,7 +33,7 @@
     }
 
     @{
-      Name = 'Exclude_Folder_Segment'
+      Name = 'exclude_folder_segment'
       Type = 'String[]'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -56,7 +56,7 @@
     }
 
     @{
-      Name = 'Days_Until_Stale'
+      Name = 'days_until_stale'
       Type = 'Int'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -91,7 +91,7 @@
     }
 
     @{
-      Name = 'Stale_Since_Date'
+      Name = 'stale_since_date'
       Type = 'DateTime'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -125,7 +125,7 @@
     }
 
     @{
-      Name = 'Upload_Artifact'
+      Name = 'upload_artifact'
       Type = 'Bool'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -166,7 +166,7 @@
     }
 
     @{
-      Name = 'Export_As_Csv'
+      Name = 'export_as_csv'
       Type = 'Bool'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -206,7 +206,7 @@
     }
 
     @{
-      Name = 'Export_Path'
+      Name = 'export_path'
       Type = 'string'
       IfNullOrEmpty = {
         param($ErrorTarget)

--- a/.github/actions/reporting/versioned-content/v1/Parameters.psd1
+++ b/.github/actions/reporting/versioned-content/v1/Parameters.psd1
@@ -1,7 +1,7 @@
 @{
   Parameters = @(
     @{
-      Name = 'Repository'
+      Name = 'repository'
       Type = 'String'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -31,7 +31,7 @@
     }
 
     @{
-      Name = 'Number'
+      Name = 'number'
       Type = 'Int'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -61,7 +61,7 @@
     }
 
     @{
-      Name = 'Include_Path_Pattern'
+      Name = 'include_path_pattern'
       Type = 'String[]'
       IfNullOrEmpty = {
         # It's okay if this parameter is not specified.
@@ -84,7 +84,7 @@
       }
     }
     @{
-      Name = 'Exclude_Path_Pattern'
+      Name = 'exclude_path_pattern'
       Type = 'String[]'
       IfNullOrEmpty = {
         # It's okay if this parameter is not specified.

--- a/.github/actions/verification/authorization/v1/Parameters.psd1
+++ b/.github/actions/verification/authorization/v1/Parameters.psd1
@@ -40,7 +40,10 @@
       Process = {
         param($Parameters, $Value, $ErrorTarget)
 
-        [string[]]$SpecifiedAccounts = $Value -split ','
+        [string[]]$SpecifiedAccounts = $Value -split ',' | Where-Object {
+           -not [string]::IsNullOrEmpty($_)
+        }
+
         if ($SpecifiedAccounts.Count -gt 0) {
           $Parameters.AuthorizedAccounts = $SpecifiedAccounts
           Write-HostParameter -Name AuthorizedAccounts -Value $Parameters.AuthorizedAccounts

--- a/.github/actions/verification/checklist/v1/Parameters.psd1
+++ b/.github/actions/verification/checklist/v1/Parameters.psd1
@@ -1,7 +1,7 @@
 @{
   Parameters = @(
     @{
-      Name = 'Body'
+      Name = 'body'
       Type = 'string'
       IfNullOrEmpty = {
         param($ErrorTarget)
@@ -30,7 +30,7 @@
     }
 
     @{
-      Name          = 'Reference_Url'
+      Name          = 'reference_url'
       Type          = 'string'
       IfNullOrEmpty = {
         param($ErrorTarget)


### PR DESCRIPTION
# PR Summary

Prior to this change, the authorization parameter handling didn't correctly handle an empty string for the `authorized_accounts` parameter. The casing for all other workflows used incorrect casing for workflow parameters, like `Message_Body` instead of `message_body`.

This change:

- Corrects the casing of all parameter handler entries.
- Ensures that the parameter handler for `authorized_accounts` only passes the parameter to the action script when the input value is a non-empty string.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
