### PR TITLE
(GHA) Fix `authorized_accounts` parameter handler

### DIFF
--- a/.github/actions/verification/authorization/v1/Parameters.psd1
+++ b/.github/actions/verification/authorization/v1/Parameters.psd1
@@ -32,11 +32,6 @@
     @{
       Name = 'authorized_accounts'
       Type = 'String[]'
-      IfNullOrEmpty = {
-          param($ErrorTarget)
-
-          # This parameter is optional, so don't error.
-      }
       Process = {
         param($Parameters, $Value, $ErrorTarget)
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the `verification/authorization/v1` workflow definition of the `authorized_accounts` parameter handler defined an empty scriptblock for the `IfNullOrEmpty` key to indicate that null/empty values are acceptable for this optional parameter. Instead, it shouldn't define the `IfNullOrEmpty` key-value pair at all. The `Get-ActionScriptParameter` helper function ignores null or empty values when the `IfNullOrEmpty` key isn't defined.

This change removes the `IfNullOrEmpty` key-value pair from the `authorized_accounts` parameter handler definition.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
