### PR TITLE
Add PipeName parameter to Invoke-RestMethod and Invoke-WebRequest docs

### DIFF
--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 02/05/2025
+ms.date: 12/04/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -329,8 +329,8 @@ pipe.
 Invoke-RestMethod -Uri 'http://localhost/status' -PipeName 'MyLocalHttpPipe'
 ```
 
-The host portion of the `-Uri` isn't used for network routing when `-PipeName` is supplied, but it
-is included in the `Host` header of the HTTP request.
+The hostname portion of the **Uri** is ignored for network routing when you supply **PipeName**, but
+it's included in the `Host` header of the HTTP request.
 
 ## PARAMETERS
 
@@ -1369,15 +1369,15 @@ Specifies the name of a local Windows named pipe to use instead of a TCP socket 
 HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
 a named pipe without opening a TCP port.
 
-Only the local machine is supported. Remote / UNC pipe names aren't supported. Supplying a value
-that doesn't correspond to a listening named pipe endpoint results in a connection failure.
+Only the local machine is supported. Remote UNC pipe names aren't supported. Supplying a value that
+doesn't correspond to a listening named pipe endpoint results in a connection failure.
 
-When `-PipeName` is specified, the `-Uri` still determines the request path, query, and scheme used
-to build the HTTP request. The host portion of the `-Uri` is ignored for network routing because
-the named pipe transport is always local, but it still appears in headers such as `Host`.
+When you specify **PipeName**, the hostname portion of the **Uri** is ignored for network routing.
+The **Uri** still determines the request path, query, and scheme used to build the HTTP request. The
+named pipe transport is always local, but the hostname still appears in HTTP headers.
 
-Security and access control for the pipe are governed by the server that created the pipe. The
-client (this cmdlet) doesn't modify pipe ACLs.
+The server that creates the pipe governs security and access control for the pipe. This cmdlet,
+acting as the client, doesn't modify pipe ACLs.
 
 This parameter was added in PowerShell 7.6.
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -32,10 +32,10 @@ Invoke-RestMethod [-FollowRelLink] [-MaximumFollowRelLink <Int32>]
  [-SkipHeaderValidation] [-AllowInsecureRedirect] [-MaximumRedirection <Int32>]
  [-MaximumRetryCount <Int32>] [-PreserveAuthorizationOnRedirect] [-RetryIntervalSec <Int32>]
  [-Method <WebRequestMethod>] [-PreserveHttpMethodOnRedirect]
- [-UnixSocket <UnixDomainSocketEndPoint>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-ProxyUseDefaultCredentials] [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>]
- [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru] [-Resume]
- [-SkipHttpErrorCheck] [<CommonParameters>]
+ [-UnixSocket <UnixDomainSocketEndPoint>] [-Pipename <String>] [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-ProxyUseDefaultCredentials] [-Body <Object>]
+ [-Form <IDictionary>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>]
+ [-OutFile <String>] [-PassThru] [-Resume] [-SkipHttpErrorCheck] [<CommonParameters>]
 ```
 
 ### StandardMethodNoProxy
@@ -52,9 +52,9 @@ Invoke-RestMethod [-FollowRelLink] [-MaximumFollowRelLink <Int32>]
  [-SkipHeaderValidation] [-AllowInsecureRedirect] [-MaximumRedirection <Int32>]
  [-MaximumRetryCount <Int32>] [-PreserveAuthorizationOnRedirect] [-RetryIntervalSec <Int32>]
  [-Method <WebRequestMethod>] [-PreserveHttpMethodOnRedirect]
- [-UnixSocket <UnixDomainSocketEndPoint>] [-NoProxy] [-Body <Object>] [-Form <IDictionary>]
- [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>]
- [-PassThru] [-Resume] [-SkipHttpErrorCheck] [<CommonParameters>]
+ [-UnixSocket <UnixDomainSocketEndPoint>] [-Pipename <String>] [-NoProxy] [-Body <Object>]
+ [-Form <IDictionary>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>]
+ [-OutFile <String>] [-PassThru] [-Resume] [-SkipHttpErrorCheck] [<CommonParameters>]
 ```
 
 ### CustomMethod
@@ -71,9 +71,10 @@ Invoke-RestMethod [-FollowRelLink] [-MaximumFollowRelLink <Int32>]
  [-SkipHeaderValidation] [-AllowInsecureRedirect] [-MaximumRedirection <Int32>]
  [-MaximumRetryCount <Int32>] [-PreserveAuthorizationOnRedirect] [-RetryIntervalSec <Int32>]
  -CustomMethod <String> [-PreserveHttpMethodOnRedirect] [-UnixSocket <UnixDomainSocketEndPoint>]
- [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-ProxyUseDefaultCredentials] [-Body <Object>]
- [-Form <IDictionary>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>]
- [-OutFile <String>] [-PassThru] [-Resume] [-SkipHttpErrorCheck] [<CommonParameters>]
+ [-Pipename <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-ProxyUseDefaultCredentials]
+ [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>] [-TransferEncoding <String>]
+ [-InFile <String>] [-OutFile <String>] [-PassThru] [-Resume] [-SkipHttpErrorCheck]
+ [<CommonParameters>]
 ```
 
 ### CustomMethodNoProxy
@@ -90,7 +91,7 @@ Invoke-RestMethod [-FollowRelLink] [-MaximumFollowRelLink <Int32>]
  [-SkipHeaderValidation] [-AllowInsecureRedirect] [-MaximumRedirection <Int32>]
  [-MaximumRetryCount <Int32>] [-PreserveAuthorizationOnRedirect] [-RetryIntervalSec <Int32>]
  -CustomMethod <String> [-PreserveHttpMethodOnRedirect] [-UnixSocket <UnixDomainSocketEndPoint>]
- [-NoProxy] [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>]
+ [-Pipename <String>] [-NoProxy] [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>]
  [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru] [-Resume]
  [-SkipHttpErrorCheck] [<CommonParameters>]
 ```
@@ -950,6 +951,40 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PipeName
+
+Specifies the name of a local Windows named pipe to use instead of a TCP socket when sending the
+HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
+a named pipe without opening a TCP port.
+
+Only the local machine is supported. Remote UNC pipe names aren't supported. Supplying a value that
+doesn't correspond to a listening named pipe endpoint results in a connection failure.
+
+When you specify **PipeName**, the hostname portion of the **Uri** is ignored for network routing.
+The **Uri** still determines the request path, query, and scheme used to build the HTTP request. The
+named pipe transport is always local, but the hostname still appears in HTTP headers.
+
+The server that creates the pipe governs security and access control for the pipe. This cmdlet,
+acting as the client, doesn't modify pipe ACLs.
+
+The **PipeName** parameter is supported only on Windows operating systems. The values for
+**UnixSocket** and **PipeName** are mutually exclusive. If you specify both parameters, the cmdlet
+only uses the value of **UnixSocket**.
+
+This parameter was added in PowerShell 7.6.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -PreserveAuthorizationOnRedirect
 
 Indicates the cmdlet should preserve the `Authorization` header, when present, across redirections.
@@ -1353,36 +1388,6 @@ This parameter was added in PowerShell 7.4.
 
 ```yaml
 Type: System.Net.Sockets.UnixDomainSocketEndPoint
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PipeName
-
-Specifies the name of a local Windows named pipe to use instead of a TCP socket when sending the
-HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
-a named pipe without opening a TCP port.
-
-Only the local machine is supported. Remote UNC pipe names aren't supported. Supplying a value that
-doesn't correspond to a listening named pipe endpoint results in a connection failure.
-
-When you specify **PipeName**, the hostname portion of the **Uri** is ignored for network routing.
-The **Uri** still determines the request path, query, and scheme used to build the HTTP request. The
-named pipe transport is always local, but the hostname still appears in HTTP headers.
-
-The server that creates the pipe governs security and access control for the pipe. This cmdlet,
-acting as the client, doesn't modify pipe ACLs.
-
-This parameter was added in PowerShell 7.6.
-
-```yaml
-Type: System.String
 Parameter Sets: (All)
 Aliases:
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -13,6 +13,7 @@ title: Invoke-RestMethod
 # Invoke-RestMethod
 
 ## SYNOPSIS
+
 Sends an HTTP or HTTPS request to a RESTful web service.
 
 ## SYNTAX
@@ -318,6 +319,18 @@ Unix socket.
 ```powershell
 Invoke-RestMethod -Uri "http://localhost/v1.40/images/json/" -UnixSocket "/var/run/docker.sock"
 ```
+
+### Example 10: Send a request over a Windows named pipe
+
+This example sends a request to a local service that exposes an HTTP endpoint over a Windows named
+pipe.
+
+```powershell
+Invoke-RestMethod -Uri 'http://localhost/status' -PipeName 'MyLocalHttpPipe'
+```
+
+The host portion of the `-Uri` isn't used for network routing when `-PipeName` is supplied, but it
+is included in the `Host` header of the HTTP request.
 
 ## PARAMETERS
 
@@ -1340,6 +1353,36 @@ This parameter was added in PowerShell 7.4.
 
 ```yaml
 Type: System.Net.Sockets.UnixDomainSocketEndPoint
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PipeName
+
+Specifies the name of a local Windows named pipe to use instead of a TCP socket when sending the
+HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
+a named pipe without opening a TCP port.
+
+Only the local machine is supported. Remote / UNC pipe names aren't supported. Supplying a value
+that doesn't correspond to a listening named pipe endpoint results in a connection failure.
+
+When `-PipeName` is specified, the `-Uri` still determines the request path, query, and scheme used
+to build the HTTP request. The host portion of the `-Uri` is ignored for network routing because
+the named pipe transport is always local, but it still appears in headers such as `Host`.
+
+Security and access control for the pipe are governed by the server that created the pipe. The
+client (this cmdlet) doesn't modify pipe ACLs.
+
+This parameter was added in PowerShell 7.6.
+
+```yaml
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -982,6 +982,40 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PipeName
+
+Specifies the name of a local Windows named pipe to use instead of a TCP socket when sending the
+HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
+a named pipe without opening a TCP port.
+
+Only the local machine is supported. Remote UNC pipe names aren't supported. Supplying a value that
+doesn't correspond to a listening named pipe endpoint results in a connection failure.
+
+When you specify **PipeName**, the hostname portion of the **Uri** is ignored for network routing.
+The **Uri** still determines the request path, query, and scheme used to build the HTTP request. The
+named pipe transport is always local, but the hostname still appears in HTTP headers.
+
+The server that creates the pipe governs security and access control for the pipe. This cmdlet,
+acting as the client, doesn't modify pipe ACLs.
+
+The **PipeName** parameter is supported only on Windows operating systems. The values for
+**UnixSocket** and **PipeName** are mutually exclusive. If you specify both parameters, the cmdlet
+only uses the value of **UnixSocket**.
+
+This parameter was added in PowerShell 7.6.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -PreserveAuthorizationOnRedirect
 
 Indicates the cmdlet should preserve the `Authorization` header, when present, across redirections.
@@ -1344,36 +1378,6 @@ This parameter was added in PowerShell 7.4.
 
 ```yaml
 Type: System.Net.Sockets.UnixDomainSocketEndPoint
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PipeName
-
-Specifies the name of a local Windows named pipe to use instead of a TCP socket when sending the
-HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
-a named pipe without opening a TCP port.
-
-Only the local machine is supported. Remote UNC pipe names aren't supported. Supplying a value that
-doesn't correspond to a listening named pipe endpoint results in a connection failure.
-
-When you specify **PipeName**, the hostname portion of the **Uri** is ignored for network routing.
-The **Uri** still determines the request path, query, and scheme used to build the HTTP request. The
-named pipe transport is always local, but the hostname still appears in HTTP headers.
-
-The server that creates the pipe governs security and access control for the pipe. This cmdlet,
-acting as the client, doesn't modify pipe ACLs.
-
-This parameter was added in PowerShell 7.6.
-
-```yaml
-Type: System.String
 Parameter Sets: (All)
 Aliases:
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -13,6 +13,7 @@ title: Invoke-WebRequest
 # Invoke-WebRequest
 
 ## SYNOPSIS
+
 Gets content from a web page on the internet.
 
 ## SYNTAX
@@ -399,6 +400,18 @@ Unix socket.
 ```powershell
 Invoke-WebRequest -Uri "http://localhost/v1.40/images/json/" -UnixSocket "/var/run/docker.sock"
 ```
+
+### Example 12: Send a request over a Windows named pipe
+
+This example sends a request to a local service that exposes an HTTP endpoint over a Windows named
+pipe.
+
+```powershell
+Invoke-WebRequest -Uri 'http://localhost/status' -PipeName 'MyLocalHttpPipe'
+```
+
+The host portion of the `-Uri` isn't used for network routing when `-PipeName` is supplied, but it
+is included in the `Host` header of the HTTP request.
 
 ## PARAMETERS
 
@@ -1331,6 +1344,36 @@ This parameter was added in PowerShell 7.4.
 
 ```yaml
 Type: System.Net.Sockets.UnixDomainSocketEndPoint
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PipeName
+
+Specifies the name of a local Windows named pipe to use instead of a TCP socket when sending the
+HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
+a named pipe without opening a TCP port.
+
+Only the local machine is supported. Remote / UNC pipe names aren't supported. Supplying a value
+that doesn't correspond to a listening named pipe endpoint results in a connection failure.
+
+When `-PipeName` is specified, the `-Uri` still determines the request path, query, and scheme used
+to build the HTTP request. The host portion of the `-Uri` is ignored for network routing because
+the named pipe transport is always local, but it still appears in headers such as `Host`.
+
+Security and access control for the pipe are governed by the server that created the pipe. The
+client (this cmdlet) doesn't modify pipe ACLs.
+
+This parameter was added in PowerShell 7.6.
+
+```yaml
+Type: System.String
 Parameter Sets: (All)
 Aliases:
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 02/05/2025
+ms.date: 12/04/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -410,8 +410,8 @@ pipe.
 Invoke-WebRequest -Uri 'http://localhost/status' -PipeName 'MyLocalHttpPipe'
 ```
 
-The host portion of the `-Uri` isn't used for network routing when `-PipeName` is supplied, but it
-is included in the `Host` header of the HTTP request.
+The hostname portion of the **Uri** is ignored for network routing when you supply **PipeName**, but
+it's included in the `Host` header of the HTTP request.
 
 ## PARAMETERS
 
@@ -1360,15 +1360,15 @@ Specifies the name of a local Windows named pipe to use instead of a TCP socket 
 HTTP request. This lets you communicate with services that expose an HTTP-compatible protocol over
 a named pipe without opening a TCP port.
 
-Only the local machine is supported. Remote / UNC pipe names aren't supported. Supplying a value
-that doesn't correspond to a listening named pipe endpoint results in a connection failure.
+Only the local machine is supported. Remote UNC pipe names aren't supported. Supplying a value that
+doesn't correspond to a listening named pipe endpoint results in a connection failure.
 
-When `-PipeName` is specified, the `-Uri` still determines the request path, query, and scheme used
-to build the HTTP request. The host portion of the `-Uri` is ignored for network routing because
-the named pipe transport is always local, but it still appears in headers such as `Host`.
+When you specify **PipeName**, the hostname portion of the **Uri** is ignored for network routing.
+The **Uri** still determines the request path, query, and scheme used to build the HTTP request. The
+named pipe transport is always local, but the hostname still appears in HTTP headers.
 
-Security and access control for the pipe are governed by the server that created the pipe. The
-client (this cmdlet) doesn't modify pipe ACLs.
+The server that creates the pipe governs security and access control for the pipe. This cmdlet,
+acting as the client, doesn't modify pipe ACLs.
 
 This parameter was added in PowerShell 7.6.
 


### PR DESCRIPTION
# Document -PipeName parameter for Invoke-RestMethod / Invoke-WebRequest (PowerShell 7.6)

## PR Summary

Documents the new `-PipeName` parameter for both `Invoke-RestMethod` and `Invoke-WebRequest` in PowerShell 7.6.
This parameter enables sending HTTP requests over a local Windows named pipe transport.
It supports scenarios where an HTTP-speaking service is exposed only via a named pipe rather than a TCP port.

Key points:

- Added parameter help section for `-PipeName` in both cmdlet help files.
- Added a new usage example to each cmdlet (`Example 10` for Invoke-RestMethod, `Example 12` for Invoke-WebRequest).
- Clarifies that `-PipeName` is Windows-only, local-only, and mutually exclusive with `-UnixSocket`.
- Notes version availability (introduced in PowerShell 7.6).
- Mirrors style and structure used for existing `-UnixSocket` parameter documentation.

Related feature implementation PR: 
- PowerShell/PowerShell#26024

(No functional engine changes are included in this PR—documentation only.)

## Additional Details / Rationale

Some self-hosted or system components expose lightweight HTTP endpoints over named pipes instead of binding to a TCP socket (for isolation or reduced surface).
Documenting `-PipeName` improves discoverability and provides parity with the previously documented `-UnixSocket` parameter.

## Changes Included

- Update: `Invoke-RestMethod.md` – new `-PipeName` parameter section + example.
- Update: `Invoke-WebRequest.md` – new `-PipeName` parameter section + example.
- Consistent wording: local-only, mutually exclusive with `-UnixSocket`, version note.

## Usage Snippets

```powershell
# Invoke-RestMethod over a local named pipe
Invoke-RestMethod -Uri 'http://localhost/status' -PipeName 'MyLocalHttpPipe'

# Invoke-WebRequest over a local named pipe
Invoke-WebRequest -Uri 'http://localhost/api/info' -PipeName 'ServiceControlPipe'
```

## Compatibility / Limitations

- Supported only on Windows (named pipes are a Windows-specific transport in this context).
- Local machine only; does not support remote pipe endpoints.
- Mutually exclusive with `-UnixSocket`.

## Related Work / Follow Ups (Optional)

- (Optional) Add CHANGELOG entry for 7.6 if not already covered by feature PR.
- (Optional) Add cross-links in conceptual docs for advanced transports.

## PR Checklist

- [x] **Descriptive Title:** Title summarizes the documentation change.
- [x] **Summary:** This PR's summary describes scope and intent.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** Adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
