### PR TITLE
Fix wrong parameter order and name for dotnet complete example of Register-ArgumentCompleter

### DIFF
--- a/reference/7.5/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -150,12 +150,14 @@ example adds tab-completion for the `dotnet` Command Line Interface (CLI).
 ```powershell
 $scriptblock = {
     param(
+        $commandName,
+        $parameterName,
         $wordToComplete,
         $commandAst,
-        $cursorPosition
+        $fakeBoundParameters
     )
 
-    dotnet complete --position $cursorPosition $commandAst.ToString() | ForEach-Object {
+    dotnet complete --position $wordToComplete $parameterName | ForEach-Object {
         [System.Management.Automation.CompletionResult]::new(
             $_,               # completionText
             $_,               # listItemText


### PR DESCRIPTION


# PR Summary

You can't ignore parameter names, they're positional. This could be very misleading because it's using the wrong names in wrong order.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
