### PR TITLE
Update about_CommonParameters.md: Pipeline variable example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the parameters that can be used with any cmdlet.
 Locale: en-US
-ms.date: 09/02/2025
+ms.date: 09/29/2025
 no-loc: [Debug, Verbose, Confirm]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -417,40 +417,39 @@ Valid values are strings, the same as for any variable names.
 > always contains the final piped item from the preceding command when used in
 > a command after the blocking command.
 
-The following is an example of how `PipelineVariable` works. In this example,
-the `PipelineVariable` parameter is added to a `ForEach-Object` command to
-store the results of the command in variables. Five number are piped into the
-first `ForEach-Object` command, the results of which are stored in a variable
-named `$Temp`.
+The following example illustrates how the `PipelineVariable` works. In this
+example, five numbers are piped into the first `ForEach-Object` command. Each
+item in the pipeline is stored in the pipeline variable named `$Temp`.
 
-The results of the first `ForEach-Object` command are piped into a downstream
-`ForEach-Object` command, which displays the current values of `$Temp` and 
-`$PSItem`.
+The `Process` block of the first `ForEach-Object` command pipes the pipeline
+item into the downstream `ForEach-Object` command. The state of the variables
+is displayed in each step.
 
 ```powershell
 # Create a variable named $Temp
 $Temp = 8
 Get-Variable Temp | Format-Table
 
-# Note that the variable just created isn't available on the
-# pipeline when -PipelineVariable creates the same variable name
 $InformationPreference = 'Continue'
-Write-Information '-----------------------------------------------------------'
+Write-Information '-------------------------------------------------'
 111,222,333,444,555 | ForEach-Object -PipelineVariable Temp -Begin {
 
-  Write-Information "Upstream (Begin):   Temp = '$Temp'"
+  # Note that the newly create $Temp variable doesn't contain the value 8
+  # assigned before the pipeline started and that $PSItem is empty in
+  # the Begin block.
+  Write-Information "Upstream (Begin):   PSItem = '$PSItem', Temp = '$Temp'"
 
 } -Process {
 
-  Write-Information "Upstream (Process): Temp = '$Temp', PSItem = '$PSItem'"
-  Return $PSItem
+  Write-Information "Upstream (Process): PSItem = '$PSItem', Temp = '$Temp'"
+  return $PSItem
 
 } | ForEach-Object -Process {
 
-  Write-Information "`t`t Downstream: Temp = '$Temp', PSItem = '$PSItem'"
+  Write-Information "`tDownstream: PSItem = '$PSItem', Temp = '$Temp'"
 
 }
-Write-Information '-----------------------------------------------------------'
+Write-Information '-------------------------------------------------'
 
 # The $Temp variable is deleted when the pipeline finishes
 Get-Variable Temp | Format-Table
@@ -461,19 +460,19 @@ Name                           Value
 ----                           -----
 Temp                           8
 
------------------------------------------------------------
-Upstream (Begin):   Temp = ''
-Upstream (Process): Temp = '', PSItem = '111'
-                 Downstream: Temp = '111', PSItem = '111'
-Upstream (Process): Temp = '111', PSItem = '222'
-                 Downstream: Temp = '222', PSItem = '222'
-Upstream (Process): Temp = '222', PSItem = '333'
-                 Downstream: Temp = '333', PSItem = '333'
-Upstream (Process): Temp = '333', PSItem = '444'
-                 Downstream: Temp = '444', PSItem = '444'
-Upstream (Process): Temp = '444', PSItem = '555'
-                 Downstream: Temp = '555', PSItem = '555'
------------------------------------------------------------
+-------------------------------------------------
+Upstream (Begin):   PSItem = '', Temp = ''
+Upstream (Process): PSItem = '111', Temp = ''
+        Downstream: PSItem = '111', Temp = '111'
+Upstream (Process): PSItem = '222', Temp = '111'
+        Downstream: PSItem = '222', Temp = '222'
+Upstream (Process): PSItem = '333', Temp = '222'
+        Downstream: PSItem = '333', Temp = '333'
+Upstream (Process): PSItem = '444', Temp = '333'
+        Downstream: PSItem = '444', Temp = '444'
+Upstream (Process): PSItem = '555', Temp = '444'
+        Downstream: PSItem = '555', Temp = '555'
+-------------------------------------------------
 
 Name                           Value
 ----                           -----
@@ -486,57 +485,55 @@ Temp
 > examples, `Get-Partition` is a CDXML function and `Get-CimInstance` is a
 > CimCmdlet.
 
-1. CDXML functions use `[CmdletBinding()]`, which allows the
-   **PipelineVariable** parameter.
+**Issue 1**: CDXML functions use `[CmdletBinding()]`, which allows the
+**PipelineVariable** parameter.
 
-   ```powershell
-   Get-Partition -pv pvar
-   ```
+```powershell
+Get-Partition -pv pvar
+```
 
-   However, when you use **PipelineVariable** in Windows PowerShell v5.1, you
-   receive the following error.
+However, when you use **PipelineVariable** in Windows PowerShell v5.1, you
+receive the following error.
 
-   ```Output
-   Get-Partition : Cannot retrieve the dynamic parameters for the cmdlet.
-   Object reference not set to an instance of an object.
+```Output
+Get-Partition : Cannot retrieve the dynamic parameters for the cmdlet.
+Object reference not set to an instance of an object.
 
-   At line:1 char:1
-   + get-partition -PipelineVariable pvar
-   + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-       + CategoryInfo          : InvalidArgument: (:) [Get-Partition], ParameterBindingException
-       + FullyQualifiedErrorId : GetDynamicParametersException,Get-Partition
-   ```
+At line:1 char:1
++ get-partition -PipelineVariable pvar
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : InvalidArgument: (:) [Get-Partition], ParameterBindingException
+    + FullyQualifiedErrorId : GetDynamicParametersException,Get-Partition
+```
 
-1. When the preceding command is _not_ a CDXML command and the downstream
-   contains either command type, the **PipelineVariable** remains as the last
-   accumulated object.
+**Issue 2**: When the preceding command is _not_ a CDXML command and the
+downstream contains either command type, the **PipelineVariable** remains as
+the last accumulated object.
 
-   ```powershell
-   Get-CimInstance Win32_DiskDrive -pv pvar |
-       ForEach-Object {
-           Write-Host "Before: $($pvar.Index)"
-           [pscustomobject]@{ DiskNumber = $_.Index }
-       } |
-       Get-Partition |
-       ForEach-Object {
-           Write-Host "After: $($pvar.Index)"
-       }
-   ```
+```powershell
+Get-CimInstance Win32_DiskDrive -pv pvar |
+    ForEach-Object {
+        Write-Host "Upstream: Disk $($pvar.Index)"
+        return [pscustomobject]@{ DiskNumber = $_.Index }
+    } | Get-Partition | ForEach-Object {
+        Write-Host "Downstream: Disk $($pvar.Index)"
+    }
+```
 
-   Notice that the value of `$pvar` set to the last object in the pipeline for
-   the second `ForEach-Object` command.
+Notice that the value of `$pvar` set to the last object in the pipeline for
+the second `ForEach-Object` command.
 
-   ```Output
-   Before: 1
-   Before: 2
-   Before: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   ```
+```Output
+Upstream: Disk 1
+Upstream: Disk 2
+Upstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+```
 
 ### -ProgressAction
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -419,55 +419,65 @@ Valid values are strings, the same as for any variable names.
 
 The following is an example of how `PipelineVariable` works. In this example,
 the `PipelineVariable` parameter is added to a `ForEach-Object` command to
-store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `ForEach-Object` command, the results of which are stored
-in a variable named `$temp`.
+store the results of the command in variables. Five number are piped into the
+first `ForEach-Object` command, the results of which are stored in a variable
+named `$Temp`.
 
-The results of the first `ForEach-Object` command are piped into a second
-`ForEach-Object` command, which displays the current values of `$temp` and
-`$_`.
+The results of the first `ForEach-Object` command are piped into a downstream
+`ForEach-Object` command, which displays the current values of `$Temp` and 
+`$PSItem`.
 
 ```powershell
-# Create a variable named $temp
-$temp=8
-Get-Variable temp
+# Create a variable named $Temp
+$Temp = 8
+Get-Variable Temp | Format-Table
+
 # Note that the variable just created isn't available on the
 # pipeline when -PipelineVariable creates the same variable name
-1..5 | ForEach-Object -PipelineVariable temp -Begin {
-    Write-Host "Step1[BEGIN]:`$temp=$temp"
+$InformationPreference = 'Continue'
+Write-Information '-----------------------------------------------------------'
+111,222,333,444,555 | ForEach-Object -PipelineVariable Temp -Begin {
+
+  Write-Information "Upstream (Begin):   Temp = '$Temp'"
+
 } -Process {
-  Write-Host "Step1[PROCESS]:`$temp=$temp - `$_=$_"
-  Write-Output $_
-} | ForEach-Object {
-  Write-Host "`tStep2[PROCESS]:`$temp=$temp - `$_=$_"
+
+  Write-Information "Upstream (Process): Temp = '$Temp', PSItem = '$PSItem'"
+  Return $PSItem
+
+} | ForEach-Object -Process {
+
+  Write-Information "`t`t Downstream: Temp = '$Temp', PSItem = '$PSItem'"
+
 }
-# The $temp variable is deleted when the pipeline finishes
-Get-Variable temp
+Write-Information '-----------------------------------------------------------'
+
+# The $Temp variable is deleted when the pipeline finishes
+Get-Variable Temp | Format-Table
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-temp                           8
+Temp                           8
 
-Step1[BEGIN]:$temp=
-Step1[PROCESS]:$temp= - $_=1
-        Step2[PROCESS]:$temp=1 - $_=1
-Step1[PROCESS]:$temp=1 - $_=2
-        Step2[PROCESS]:$temp=2 - $_=2
-Step1[PROCESS]:$temp=2 - $_=3
-        Step2[PROCESS]:$temp=3 - $_=3
-Step1[PROCESS]:$temp=3 - $_=4
-        Step2[PROCESS]:$temp=4 - $_=4
-Step1[PROCESS]:$temp=4 - $_=5
-        Step2[PROCESS]:$temp=5 - $_=5
+-----------------------------------------------------------
+Upstream (Begin):   Temp = ''
+Upstream (Process): Temp = '', PSItem = '111'
+                 Downstream: Temp = '111', PSItem = '111'
+Upstream (Process): Temp = '111', PSItem = '222'
+                 Downstream: Temp = '222', PSItem = '222'
+Upstream (Process): Temp = '222', PSItem = '333'
+                 Downstream: Temp = '333', PSItem = '333'
+Upstream (Process): Temp = '333', PSItem = '444'
+                 Downstream: Temp = '444', PSItem = '444'
+Upstream (Process): Temp = '444', PSItem = '555'
+                 Downstream: Temp = '555', PSItem = '555'
+-----------------------------------------------------------
 
-Get-Variable : Cannot find a variable with the name 'temp'.
-At line:1 char:1
-+ Get-Variable temp
-+ ~~~~~~~~~~~~~~~~~
-    + CategoryInfo          : ObjectNotFound: (temp:String) [Get-Variable], ItemNotFoundException
-    + FullyQualifiedErrorId : VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand
+Name                           Value
+----                           -----
+Temp
 ```
 
 > [!CAUTION]

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -409,52 +409,65 @@ Valid values are strings, the same as for any variable names.
 
 The following is an example of how `PipelineVariable` works. In this example,
 the `PipelineVariable` parameter is added to a `ForEach-Object` command to
-store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `ForEach-Object` command, the results of which are stored
-in a variable named `$temp`.
+store the results of the command in variables. Five number are piped into the
+first `ForEach-Object` command, the results of which are stored in a variable
+named `$Temp`.
 
-The results of the first `ForEach-Object` command are piped into a second
-`ForEach-Object` command, which displays the current values of `$temp` and
-`$_`.
+The results of the first `ForEach-Object` command are piped into a downstream
+`ForEach-Object` command, which displays the current values of `$Temp` and 
+`$PSItem`.
 
 ```powershell
-# Create a variable named $temp
-$temp=8
-Get-Variable temp
+# Create a variable named $Temp
+$Temp = 8
+Get-Variable Temp | Format-Table
+
 # Note that the variable just created isn't available on the
 # pipeline when -PipelineVariable creates the same variable name
-1..5 | ForEach-Object -PipelineVariable temp -Begin {
-    Write-Host "Step1[BEGIN]:`$temp=$temp"
+$InformationPreference = 'Continue'
+Write-Information '-----------------------------------------------------------'
+111,222,333,444,555 | ForEach-Object -PipelineVariable Temp -Begin {
+
+  Write-Information "Upstream (Begin):   Temp = '$Temp'"
+
 } -Process {
-  Write-Host "Step1[PROCESS]:`$temp=$temp - `$_=$_"
-  Write-Output $_
-} | ForEach-Object {
-  Write-Host "`tStep2[PROCESS]:`$temp=$temp - `$_=$_"
+
+  Write-Information "Upstream (Process): Temp = '$Temp', PSItem = '$PSItem'"
+  Return $PSItem
+
+} | ForEach-Object -Process {
+
+  Write-Information "`t`t Downstream: Temp = '$Temp', PSItem = '$PSItem'"
+
 }
-# The $temp variable is deleted when the pipeline finishes
-Get-Variable temp
+Write-Information '-----------------------------------------------------------'
+
+# The $Temp variable is deleted when the pipeline finishes
+Get-Variable Temp | Format-Table
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-temp                           8
+Temp                           8
 
-Step1[BEGIN]:$temp=
-Step1[PROCESS]:$temp= - $_=1
-        Step2[PROCESS]:$temp=1 - $_=1
-Step1[PROCESS]:$temp=1 - $_=2
-        Step2[PROCESS]:$temp=2 - $_=2
-Step1[PROCESS]:$temp=2 - $_=3
-        Step2[PROCESS]:$temp=3 - $_=3
-Step1[PROCESS]:$temp=3 - $_=4
-        Step2[PROCESS]:$temp=4 - $_=4
-Step1[PROCESS]:$temp=4 - $_=5
-        Step2[PROCESS]:$temp=5 - $_=5
+-----------------------------------------------------------
+Upstream (Begin):   Temp = ''
+Upstream (Process): Temp = '', PSItem = '111'
+                 Downstream: Temp = '111', PSItem = '111'
+Upstream (Process): Temp = '111', PSItem = '222'
+                 Downstream: Temp = '222', PSItem = '222'
+Upstream (Process): Temp = '222', PSItem = '333'
+                 Downstream: Temp = '333', PSItem = '333'
+Upstream (Process): Temp = '333', PSItem = '444'
+                 Downstream: Temp = '444', PSItem = '444'
+Upstream (Process): Temp = '444', PSItem = '555'
+                 Downstream: Temp = '555', PSItem = '555'
+-----------------------------------------------------------
 
 Name                           Value
 ----                           -----
-temp
+Temp
 ```
 
 > [!CAUTION]

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -409,52 +409,65 @@ Valid values are strings, the same as for any variable names.
 
 The following is an example of how `PipelineVariable` works. In this example,
 the `PipelineVariable` parameter is added to a `ForEach-Object` command to
-store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `ForEach-Object` command, the results of which are stored
-in a variable named `$temp`.
+store the results of the command in variables. Five number are piped into the
+first `ForEach-Object` command, the results of which are stored in a variable
+named `$Temp`.
 
-The results of the first `ForEach-Object` command are piped into a second
-`ForEach-Object` command, which displays the current values of `$temp` and
-`$_`.
+The results of the first `ForEach-Object` command are piped into a downstream
+`ForEach-Object` command, which displays the current values of `$Temp` and 
+`$PSItem`.
 
 ```powershell
-# Create a variable named $temp
-$temp=8
-Get-Variable temp
+# Create a variable named $Temp
+$Temp = 8
+Get-Variable Temp | Format-Table
+
 # Note that the variable just created isn't available on the
 # pipeline when -PipelineVariable creates the same variable name
-1..5 | ForEach-Object -PipelineVariable temp -Begin {
-    Write-Host "Step1[BEGIN]:`$temp=$temp"
+$InformationPreference = 'Continue'
+Write-Information '-----------------------------------------------------------'
+111,222,333,444,555 | ForEach-Object -PipelineVariable Temp -Begin {
+
+  Write-Information "Upstream (Begin):   Temp = '$Temp'"
+
 } -Process {
-  Write-Host "Step1[PROCESS]:`$temp=$temp - `$_=$_"
-  Write-Output $_
-} | ForEach-Object {
-  Write-Host "`tStep2[PROCESS]:`$temp=$temp - `$_=$_"
+
+  Write-Information "Upstream (Process): Temp = '$Temp', PSItem = '$PSItem'"
+  Return $PSItem
+
+} | ForEach-Object -Process {
+
+  Write-Information "`t`t Downstream: Temp = '$Temp', PSItem = '$PSItem'"
+
 }
-# The $temp variable is deleted when the pipeline finishes
-Get-Variable temp
+Write-Information '-----------------------------------------------------------'
+
+# The $Temp variable is deleted when the pipeline finishes
+Get-Variable Temp | Format-Table
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-temp                           8
+Temp                           8
 
-Step1[BEGIN]:$temp=
-Step1[PROCESS]:$temp= - $_=1
-        Step2[PROCESS]:$temp=1 - $_=1
-Step1[PROCESS]:$temp=1 - $_=2
-        Step2[PROCESS]:$temp=2 - $_=2
-Step1[PROCESS]:$temp=2 - $_=3
-        Step2[PROCESS]:$temp=3 - $_=3
-Step1[PROCESS]:$temp=3 - $_=4
-        Step2[PROCESS]:$temp=4 - $_=4
-Step1[PROCESS]:$temp=4 - $_=5
-        Step2[PROCESS]:$temp=5 - $_=5
+-----------------------------------------------------------
+Upstream (Begin):   Temp = ''
+Upstream (Process): Temp = '', PSItem = '111'
+                 Downstream: Temp = '111', PSItem = '111'
+Upstream (Process): Temp = '111', PSItem = '222'
+                 Downstream: Temp = '222', PSItem = '222'
+Upstream (Process): Temp = '222', PSItem = '333'
+                 Downstream: Temp = '333', PSItem = '333'
+Upstream (Process): Temp = '333', PSItem = '444'
+                 Downstream: Temp = '444', PSItem = '444'
+Upstream (Process): Temp = '444', PSItem = '555'
+                 Downstream: Temp = '555', PSItem = '555'
+-----------------------------------------------------------
 
 Name                           Value
 ----                           -----
-temp
+Temp
 ```
 
 > [!CAUTION]

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the parameters that can be used with any cmdlet.
 Locale: en-US
-ms.date: 09/02/2025
+ms.date: 09/29/2025
 no-loc: [Debug, Verbose, Confirm]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -407,40 +407,39 @@ Valid values are strings, the same as for any variable names.
 > always contains the final piped item from the preceding command when used in
 > a command after the blocking command.
 
-The following is an example of how `PipelineVariable` works. In this example,
-the `PipelineVariable` parameter is added to a `ForEach-Object` command to
-store the results of the command in variables. Five number are piped into the
-first `ForEach-Object` command, the results of which are stored in a variable
-named `$Temp`.
+The following example illustrates how the `PipelineVariable` works. In this
+example, five numbers are piped into the first `ForEach-Object` command. Each
+item in the pipeline is stored in the pipeline variable named `$Temp`.
 
-The results of the first `ForEach-Object` command are piped into a downstream
-`ForEach-Object` command, which displays the current values of `$Temp` and 
-`$PSItem`.
+The `Process` block of the first `ForEach-Object` command pipes the pipeline
+item into the downstream `ForEach-Object` command. The state of the variables
+is displayed in each step.
 
 ```powershell
 # Create a variable named $Temp
 $Temp = 8
 Get-Variable Temp | Format-Table
 
-# Note that the variable just created isn't available on the
-# pipeline when -PipelineVariable creates the same variable name
 $InformationPreference = 'Continue'
-Write-Information '-----------------------------------------------------------'
+Write-Information '-------------------------------------------------'
 111,222,333,444,555 | ForEach-Object -PipelineVariable Temp -Begin {
 
-  Write-Information "Upstream (Begin):   Temp = '$Temp'"
+  # Note that the newly create $Temp variable doesn't contain the value 8
+  # assigned before the pipeline started and that $PSItem is empty in
+  # the Begin block.
+  Write-Information "Upstream (Begin):   PSItem = '$PSItem', Temp = '$Temp'"
 
 } -Process {
 
-  Write-Information "Upstream (Process): Temp = '$Temp', PSItem = '$PSItem'"
-  Return $PSItem
+  Write-Information "Upstream (Process): PSItem = '$PSItem', Temp = '$Temp'"
+  return $PSItem
 
 } | ForEach-Object -Process {
 
-  Write-Information "`t`t Downstream: Temp = '$Temp', PSItem = '$PSItem'"
+  Write-Information "`tDownstream: PSItem = '$PSItem', Temp = '$Temp'"
 
 }
-Write-Information '-----------------------------------------------------------'
+Write-Information '-------------------------------------------------'
 
 # The $Temp variable is deleted when the pipeline finishes
 Get-Variable Temp | Format-Table
@@ -451,19 +450,19 @@ Name                           Value
 ----                           -----
 Temp                           8
 
------------------------------------------------------------
-Upstream (Begin):   Temp = ''
-Upstream (Process): Temp = '', PSItem = '111'
-                 Downstream: Temp = '111', PSItem = '111'
-Upstream (Process): Temp = '111', PSItem = '222'
-                 Downstream: Temp = '222', PSItem = '222'
-Upstream (Process): Temp = '222', PSItem = '333'
-                 Downstream: Temp = '333', PSItem = '333'
-Upstream (Process): Temp = '333', PSItem = '444'
-                 Downstream: Temp = '444', PSItem = '444'
-Upstream (Process): Temp = '444', PSItem = '555'
-                 Downstream: Temp = '555', PSItem = '555'
------------------------------------------------------------
+-------------------------------------------------
+Upstream (Begin):   PSItem = '', Temp = ''
+Upstream (Process): PSItem = '111', Temp = ''
+        Downstream: PSItem = '111', Temp = '111'
+Upstream (Process): PSItem = '222', Temp = '111'
+        Downstream: PSItem = '222', Temp = '222'
+Upstream (Process): PSItem = '333', Temp = '222'
+        Downstream: PSItem = '333', Temp = '333'
+Upstream (Process): PSItem = '444', Temp = '333'
+        Downstream: PSItem = '444', Temp = '444'
+Upstream (Process): PSItem = '555', Temp = '444'
+        Downstream: PSItem = '555', Temp = '555'
+-------------------------------------------------
 
 Name                           Value
 ----                           -----
@@ -471,75 +470,60 @@ Temp
 ```
 
 > [!CAUTION]
-> There are two known issues with using the `PipelineVariable` parameter in a
+> There are two known issues with using the **PipelineVariable** parameter in a
 > pipeline that includes CimCmdlets or CDXML cmdlets. In the following
 > examples, `Get-Partition` is a CDXML function and `Get-CimInstance` is a
 > CimCmdlet.
 
-1. When the first command is a CDXML function and downstream contains either a
-   CimCmdlet cmdlet or CDXML function, `PipelineVariable` is reset to
-   `$null`.
+**Issue 1**: CDXML functions use `[CmdletBinding()]`, which allows the
+**PipelineVariable** parameter.
 
-   ```powershell
-   Get-Partition -pv pvar |
-       ForEach-Object {
-           Write-Host "Before: $($pvar.PartitionNumber)"
-           [pscustomobject]@{Filter = "Index = $($_.DiskNumber)"}
-       } |
-       Get-CimInstance Win32_DiskDrive |
-       ForEach-Object {
-           Write-Host "After: $($pvar.PartitionNumber)"
-       }
-   ```
+```powershell
+Get-Partition -pv pvar
+```
 
-   Notice that the value of `$pvar` set to `$null` in the pipeline for the
-   second `ForEach-Object` command.
+However, when you use **PipelineVariable** in Windows PowerShell v5.1, you
+receive the following error.
 
-   ```Output
-   Before: 1
-   Before: 1
-   Before: 2
-   Before: 3
-   Before: 4
-   Before: 1
-   After:
-   After:
-   After:
-   After:
-   After:
-   After:
-   ```
+```Output
+Get-Partition : Cannot retrieve the dynamic parameters for the cmdlet.
+Object reference not set to an instance of an object.
 
-1. When the preceding command is _not_ a CDXML command and the downstream
-   contains either command type, the `PipelineVariable` remains as the last
-   accumulated object.
+At line:1 char:1
++ get-partition -PipelineVariable pvar
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : InvalidArgument: (:) [Get-Partition], ParameterBindingException
+    + FullyQualifiedErrorId : GetDynamicParametersException,Get-Partition
+```
 
-   ```powershell
-   Get-CimInstance Win32_DiskDrive -pv pvar |
-       ForEach-Object {
-           Write-Host "Before: $($pvar.Index)"
-           [pscustomobject]@{ DiskNumber = $_.Index }
-       } |
-       Get-Partition |
-       ForEach-Object {
-           Write-Host "After: $($pvar.Index)"
-       }
-   ```
+**Issue 2**: When the preceding command is _not_ a CDXML command and the
+downstream contains either command type, the **PipelineVariable** remains as
+the last accumulated object.
 
-   Notice that the value of `$pvar` set to the last object in the pipeline for
-   the second `ForEach-Object` command.
+```powershell
+Get-CimInstance Win32_DiskDrive -pv pvar |
+    ForEach-Object {
+        Write-Host "Upstream: Disk $($pvar.Index)"
+        return [pscustomobject]@{ DiskNumber = $_.Index }
+    } | Get-Partition | ForEach-Object {
+        Write-Host "Downstream: Disk $($pvar.Index)"
+    }
+```
 
-   ```Output
-   Before: 1
-   Before: 2
-   Before: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   ```
+Notice that the value of `$pvar` set to the last object in the pipeline for
+the second `ForEach-Object` command.
+
+```Output
+Upstream: Disk 1
+Upstream: Disk 2
+Upstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+```
 
 ### -ProgressAction
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the parameters that can be used with any cmdlet.
 Locale: en-US
-ms.date: 09/02/2025
+ms.date: 09/29/2025
 no-loc: [Debug, Verbose, Confirm]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -407,126 +407,123 @@ Valid values are strings, the same as for any variable names.
 > always contains the final piped item from the preceding command when used in
 > a command after the blocking command.
 
-The following is an example of how `PipelineVariable` works. In this example,
-the `PipelineVariable` parameter is added to a `ForEach-Object` command to
-store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `ForEach-Object` command, the results of which are stored
-in a variable named `$temp`.
+The following example illustrates how the `PipelineVariable` works. In this
+example, five numbers are piped into the first `ForEach-Object` command. Each
+item in the pipeline is stored in the pipeline variable named `$Temp`.
 
-The results of the first `ForEach-Object` command are piped into a second
-`ForEach-Object` command, which displays the current values of `$temp` and
-`$_`.
+The `Process` block of the first `ForEach-Object` command pipes the pipeline
+item into the downstream `ForEach-Object` command. The state of the variables
+is displayed in each step.
 
 ```powershell
-# Create a variable named $temp
-$temp=8
-Get-Variable temp
-# Note that the variable just created isn't available on the
-# pipeline when -PipelineVariable creates the same variable name
-1..5 | ForEach-Object -PipelineVariable temp -Begin {
-    Write-Host "Step1[BEGIN]:`$temp=$temp"
+# Create a variable named $Temp
+$Temp = 8
+Get-Variable Temp | Format-Table
+
+$InformationPreference = 'Continue'
+Write-Information '-------------------------------------------------'
+111,222,333,444,555 | ForEach-Object -PipelineVariable Temp -Begin {
+
+  # Note that the newly create $Temp variable doesn't contain the value 8
+  # assigned before the pipeline started and that $PSItem is empty in
+  # the Begin block.
+  Write-Information "Upstream (Begin):   PSItem = '$PSItem', Temp = '$Temp'"
+
 } -Process {
-  Write-Host "Step1[PROCESS]:`$temp=$temp - `$_=$_"
-  Write-Output $_
-} | ForEach-Object {
-  Write-Host "`tStep2[PROCESS]:`$temp=$temp - `$_=$_"
+
+  Write-Information "Upstream (Process): PSItem = '$PSItem', Temp = '$Temp'"
+  return $PSItem
+
+} | ForEach-Object -Process {
+
+  Write-Information "`tDownstream: PSItem = '$PSItem', Temp = '$Temp'"
+
 }
-# The $temp variable is deleted when the pipeline finishes
-Get-Variable temp
+Write-Information '-------------------------------------------------'
+
+# The $Temp variable is deleted when the pipeline finishes
+Get-Variable Temp | Format-Table
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-temp                           8
+Temp                           8
 
-Step1[BEGIN]:$temp=
-Step1[PROCESS]:$temp= - $_=1
-        Step2[PROCESS]:$temp=1 - $_=1
-Step1[PROCESS]:$temp=1 - $_=2
-        Step2[PROCESS]:$temp=2 - $_=2
-Step1[PROCESS]:$temp=2 - $_=3
-        Step2[PROCESS]:$temp=3 - $_=3
-Step1[PROCESS]:$temp=3 - $_=4
-        Step2[PROCESS]:$temp=4 - $_=4
-Step1[PROCESS]:$temp=4 - $_=5
-        Step2[PROCESS]:$temp=5 - $_=5
+-------------------------------------------------
+Upstream (Begin):   PSItem = '', Temp = ''
+Upstream (Process): PSItem = '111', Temp = ''
+        Downstream: PSItem = '111', Temp = '111'
+Upstream (Process): PSItem = '222', Temp = '111'
+        Downstream: PSItem = '222', Temp = '222'
+Upstream (Process): PSItem = '333', Temp = '222'
+        Downstream: PSItem = '333', Temp = '333'
+Upstream (Process): PSItem = '444', Temp = '333'
+        Downstream: PSItem = '444', Temp = '444'
+Upstream (Process): PSItem = '555', Temp = '444'
+        Downstream: PSItem = '555', Temp = '555'
+-------------------------------------------------
 
 Name                           Value
 ----                           -----
-temp
+Temp
 ```
 
 > [!CAUTION]
-> There are two known issues with using the `PipelineVariable` parameter in a
+> There are two known issues with using the **PipelineVariable** parameter in a
 > pipeline that includes CimCmdlets or CDXML cmdlets. In the following
 > examples, `Get-Partition` is a CDXML function and `Get-CimInstance` is a
 > CimCmdlet.
 
-1. When the first command is a CDXML function and downstream contains either a
-   CimCmdlet cmdlet or CDXML function, `PipelineVariable` is reset to
-   `$null`.
+**Issue 1**: CDXML functions use `[CmdletBinding()]`, which allows the
+**PipelineVariable** parameter.
 
-   ```powershell
-   Get-Partition -pv pvar |
-       ForEach-Object {
-           Write-Host "Before: $($pvar.PartitionNumber)"
-           [pscustomobject]@{Filter = "Index = $($_.DiskNumber)"}
-       } |
-       Get-CimInstance Win32_DiskDrive |
-       ForEach-Object {
-           Write-Host "After: $($pvar.PartitionNumber)"
-       }
-   ```
+```powershell
+Get-Partition -pv pvar
+```
 
-   Notice that the value of `$pvar` set to `$null` in the pipeline for the
-   second `ForEach-Object` command.
+However, when you use **PipelineVariable** in Windows PowerShell v5.1, you
+receive the following error.
 
-   ```Output
-   Before: 1
-   Before: 1
-   Before: 2
-   Before: 3
-   Before: 4
-   Before: 1
-   After:
-   After:
-   After:
-   After:
-   After:
-   After:
-   ```
+```Output
+Get-Partition : Cannot retrieve the dynamic parameters for the cmdlet.
+Object reference not set to an instance of an object.
 
-1. When the preceding command is _not_ a CDXML command and the downstream
-   contains either command type, the `PipelineVariable` remains as the last
-   accumulated object.
+At line:1 char:1
++ get-partition -PipelineVariable pvar
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : InvalidArgument: (:) [Get-Partition], ParameterBindingException
+    + FullyQualifiedErrorId : GetDynamicParametersException,Get-Partition
+```
 
-   ```powershell
-   Get-CimInstance Win32_DiskDrive -pv pvar |
-       ForEach-Object {
-           Write-Host "Before: $($pvar.Index)"
-           [pscustomobject]@{ DiskNumber = $_.Index }
-       } |
-       Get-Partition |
-       ForEach-Object {
-           Write-Host "After: $($pvar.Index)"
-       }
-   ```
+**Issue 2**: When the preceding command is _not_ a CDXML command and the
+downstream contains either command type, the **PipelineVariable** remains as
+the last accumulated object.
 
-   Notice that the value of `$pvar` set to the last object in the pipeline for
-   the second `ForEach-Object` command.
+```powershell
+Get-CimInstance Win32_DiskDrive -pv pvar |
+    ForEach-Object {
+        Write-Host "Upstream: Disk $($pvar.Index)"
+        return [pscustomobject]@{ DiskNumber = $_.Index }
+    } | Get-Partition | ForEach-Object {
+        Write-Host "Downstream: Disk $($pvar.Index)"
+    }
+```
 
-   ```Output
-   Before: 1
-   Before: 2
-   Before: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   After: 0
-   ```
+Notice that the value of `$pvar` set to the last object in the pipeline for
+the second `ForEach-Object` command.
+
+```Output
+Upstream: Disk 1
+Upstream: Disk 2
+Upstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+Downstream: Disk 0
+```
 
 ### -ProgressAction
 


### PR DESCRIPTION
# PR Summary

Following a series of questions by a PowerShell learner, I realized that the `PipelineVariable` example in this document is counterintuitive. So, I wrote a better one.

Here are the questions:

1. Why is the output different on my PC?
2. Why is the counter always -1 or 0?
3. Why are a mix of `Write-Host` and `Write-Output` commands in the example? Isn't `Write-Host` supposed to be evil?
4. Why do I get different results when I uniformly use `Write-Host` or `Write-Output`?

Here are my answers.

### 1: Why is the output different on my PC?

The output isn't different when you paste the original code into Windows Terminal, regardless of PowerShell's version. But if you:

- Paste the example into the prompt line of PowerShell 7.5 inside Console Host
- Run the example from a PS1 file
- Paste the example into the prompt line between `&{` and `}`

...you get the following output, the last line of which poses a mental hurdle for a newbie. Examples are supposed to clarify, not befuddle.

```Output
Name                           Value
----                           -----
temp                           8
Step1[BEGIN]:$temp=
Step1[PROCESS]:$temp= - $_=1
        Step2[PROCESS]:$temp=1 - $_=1
Step1[PROCESS]:$temp=1 - $_=2
        Step2[PROCESS]:$temp=2 - $_=2
Step1[PROCESS]:$temp=2 - $_=3
        Step2[PROCESS]:$temp=3 - $_=3
Step1[PROCESS]:$temp=3 - $_=4
        Step2[PROCESS]:$temp=4 - $_=4
Step1[PROCESS]:$temp=4 - $_=5
        Step2[PROCESS]:$temp=5 - $_=5
temp
```

Pasting the example into the prompt line of PowerShell 5.1 inside the Console Host generates a different result:

```Output
Name                           Value
----                           -----
temp                           8
Step1[BEGIN]:$temp=
Step1[PROCESS]:$temp= - $_=1
        Step2[PROCESS]:$temp=1 - $_=1
Step1[PROCESS]:$temp=1 - $_=2
        Step2[PROCESS]:$temp=2 - $_=2
Step1[PROCESS]:$temp=2 - $_=3
        Step2[PROCESS]:$temp=3 - $_=3
Step1[PROCESS]:$temp=3 - $_=4
        Step2[PROCESS]:$temp=4 - $_=4
Step1[PROCESS]:$temp=4 - $_=5
        Step2[PROCESS]:$temp=5 - $_=5
Get-Variable : Cannot find a variable with the name 'temp'.
At line:15 char:1
+ Get-Variable temp
+ ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (temp:String) [Get-Variable], ItemNotFoundException
    + FullyQualifiedErrorId : VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand
```

This is much better. Instead of a mysterious "temp" out of nowhere, we have a clear error message.

**My solution:** I used `Format-Table` and deliberately added empty lines. To be honest, though, I added the empty lines for readability. It wasn't until later when I discovered the effect they have on the Console Host.

### 2: Why is the counter always -1 or 0?

To be honest, the OP didn't put the question in this precise fashion. It took me a while to understand the issue.

Firstly, `$_` is not the counter. It's the iterator. The PowerShell team has already recognized this concern a long time ago, and introduced `$PSItem`.

Secondly, there is a miscommunication. The output isn't saying "1 - $PSItem = 2". It is saying:

- `$Temp` equals 1
- `$PSItem` equals 2

**My solution:**

- Use `$PSItem` instead of `$_`
- Use a different input array: 111, 222, 333, 444, and 555
- Put the value between quotation marks.
- Use different wording:
  ```output
  Upstream (Process): Temp = '', PSItem = '111'
                 Downstream: Temp = '111', PSItem = '111'
  ```

### 4 and 5: `Write-Host` vs. `Write-Output`

No, `Write-Host` isn't evil. But mixing `Write-Host` and `Write-Output` is bound to trigger unfathomable conditions, and here, we have one. Newbies don't immediately grasp that `Write-Output` emits to pipeline, while `Write-Host` writes directly to the screen device. Hence, the use of `Write-Output` is counterintuitive.

**My solution:**

- Use `Write-Information` to emit to screen.
- Use `return` instead of `Write-Output` to emit to pipeline.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributor's guide].
- [X] **Style:** This PR adheres to the [style guide].

[contributor's guide]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style guide]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
