### PR TITLE
Update hashtable documentation with cloning note

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-hashtable.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-hashtable.md
@@ -1,7 +1,7 @@
 ---
 description: Hashtables are really important in PowerShell so it's good to have a solid understanding of them.
 ms.custom: contributor-KevinMarquette
-ms.date: 06/25/2023
+ms.date: 10/22/2025
 title: Everything you wanted to know about hashtables
 ---
 # Everything you wanted to know about hashtables
@@ -269,7 +269,9 @@ $environments.Keys.Clone() | ForEach-Object {
 }
 ```
 
-Do note, you cannot clone a hashtable containing a single key, that will throw an error. In such case where you want to clone the keys its better to cast the key(s) to an array instead and iterate over them. 
+> [!NOTE]
+> You can't clone a hashtable containing a single key. PowerShell throws an error. Instead, you
+> convert the **Keys** property to an array, then iterate over the array.
 
 ```powershell
 @($environments.Keys) | ForEach-Object {


### PR DESCRIPTION
Added note about cloning hashtables with a single key and provided an example using PowerShell.

# PR Summary

This changes fixes problem in documentation containg how to clone hashtable keys to enumerate over them when the hashtable contains a single key. 

<img width="800" height="64" alt="image" src="https://github.com/user-attachments/assets/a8220ef6-8904-4ce4-a5cf-e3b3d9519445" />
