### PR TITLE
using-aliases.md - fix 'mv' typo 

### DIFF
--- a/reference/docs-conceptual/learn/shell/using-aliases.md
+++ b/reference/docs-conceptual/learn/shell/using-aliases.md
@@ -81,7 +81,7 @@ alias:
 | `dir`                         | `ls`         | `Get-ChildItem`   | `gci`, `dir`, `ls`                        |
 | `echo`                        | `echo`       | `Write-Output`    | `write` `echo`                            |
 | `md`                          | `mkdir`      | `New-Item`        | `ni`                                      |
-| `move`                        | `mv`         | `Move-Item`       | `mi`, `move`, `mi`                        |
+| `move`                        | `mv`         | `Move-Item`       | `mi`, `move`, `mv`                        |
 | `popd`                        | `popd`       | `Pop-Location`    | `popd`                                    |
 |                               | `pwd`        | `Get-Location`    | `gl`, `pwd`                               |
 | `pushd`                       | `pushd`      | `Push-Location`   | `pushd`                                   |


### PR DESCRIPTION
There is a typo in the documentation for move-item, where 'mi' is listed twice, and 'mv' is not mentioned. I replaced the second mention of 'mi' with 'mv'.