### PR TITLE
Add Note regarding Scriptblock behaviour exception

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/31/2024
+ms.date: 01/20/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/import-clixml?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Clixml
@@ -47,6 +47,10 @@ The **TypeNames** property contains the original type name prefixed with `Deseri
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
+
+> [!NOTE]
+> `[System.Management.Automation.ScriptBlock]` objects are serialized into the `<SKB>` element in
+> CLIXML. However, the `<SKB>` element is always deserialized to **Strings**.
 
 For more information about CLI, see
 [Language independence](/dotnet/standard/language-independence).

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/31/2024
+ms.date: 01/20/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/import-clixml?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Clixml
@@ -47,6 +47,10 @@ The **TypeNames** property contains the original type name prefixed with `Deseri
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
+
+> [!NOTE]
+> `[System.Management.Automation.ScriptBlock]` objects are serialized into the `<SKB>` element in
+> CLIXML. However, the `<SKB>` element is always deserialized to **Strings**.
 
 For more information about CLI, see
 [Language independence](/dotnet/standard/language-independence).

--- a/reference/7.5/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/31/2024
+ms.date: 01/20/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/import-clixml?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Clixml
@@ -49,7 +49,8 @@ The **TypeNames** property contains the original type name prefixed with `Deseri
 file has no BOM, it assumes the encoding is UTF8.
 
 > [!NOTE]
->**Scriptblocks** are always deserialized to **strings** due to security concerns regarding automatic code execution.
+> `[System.Management.Automation.ScriptBlock]` objects are serialized into the `<SKB>` element in
+> CLIXML. However, the `<SKB>` element is always deserialized to **Strings**.
 
 For more information about CLI, see
 [Language independence](/dotnet/standard/language-independence).

--- a/reference/7.6/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/31/2024
+ms.date: 01/20/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/import-clixml?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Clixml
@@ -47,6 +47,10 @@ The **TypeNames** property contains the original type name prefixed with `Deseri
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
+
+> [!NOTE]
+> `[System.Management.Automation.ScriptBlock]` objects are serialized into the `<SKB>` element in
+> CLIXML. However, the `<SKB>` element is always deserialized to **Strings**.
 
 For more information about CLI, see
 [Language independence](/dotnet/standard/language-independence).


### PR DESCRIPTION
# PR Summary

This adds a note to highlight that `Import-Clixml` will deserialize a **scriptblock** as a **string**.

Despite `Export-Clixml` suggesting that it would retain the type by using a` <SKB> `element instead of `<S>`

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].



[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
