### PR TITLE
(AB-506233) Clarify note in `Remove-Item`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 02/14/2023
+ms.date: 01/28/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/remove-item?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -130,7 +130,18 @@ cmdlet interprets the subject of the search to be a file that has no child items
 fails.
 
 > [!NOTE]
-> This behavior was fixed in Windows versions 1909 and up.
+> Starting in Windows version 1909, specifying the file type in the **Path** parameter when using
+> the **Recurse** parameter does recursively discover child items with the given file extension.
+>
+> In Windows version 1909 and later, the following statements will discover and remove the same
+> files:
+>
+> ```powershell
+> # Works in all versions of Windows:
+> Get-ChildItem -Path * -Include *.csv -Recurse | Remove-Item
+> # Only correctly finds and removes nested CSV files in Windows 1909 and later:
+> Get-ChildItem -Path *.csv -Recurse | Remove-Item
+> ```
 
 ### Example 5: Delete subkeys recursively
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Remove-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 02/14/2023
+ms.date: 01/28/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/remove-item?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -128,7 +128,18 @@ cmdlet interprets the subject of the search to be a file that has no child items
 fails.
 
 > [!NOTE]
-> This behavior was fixed in Windows versions 1909 and up.
+> Starting in Windows version 1909, specifying the file type in the **Path** parameter when using
+> the **Recurse** parameter does recursively discover child items with the given file extension.
+>
+> In Windows version 1909 and later, the following statements will discover and remove the same
+> files:
+>
+> ```powershell
+> # Works in all versions of Windows:
+> Get-ChildItem -Path * -Include *.csv -Recurse | Remove-Item
+> # Only correctly finds and removes nested CSV files in Windows 1909 and later:
+> Get-ChildItem -Path *.csv -Recurse | Remove-Item
+> ```
 
 ### Example 5: Delete subkeys recursively
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Remove-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 02/14/2023
+ms.date: 01/28/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/remove-item?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -128,7 +128,18 @@ cmdlet interprets the subject of the search to be a file that has no child items
 fails.
 
 > [!NOTE]
-> This behavior was fixed in Windows versions 1909 and up.
+> Starting in Windows version 1909, specifying the file type in the **Path** parameter when using
+> the **Recurse** parameter does recursively discover child items with the given file extension.
+>
+> In Windows version 1909 and later, the following statements will discover and remove the same
+> files:
+>
+> ```powershell
+> # Works in all versions of Windows:
+> Get-ChildItem -Path * -Include *.csv -Recurse | Remove-Item
+> # Only correctly finds and removes nested CSV files in Windows 1909 and later:
+> Get-ChildItem -Path *.csv -Recurse | Remove-Item
+> ```
 
 ### Example 5: Delete subkeys recursively
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Remove-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 02/14/2023
+ms.date: 01/28/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/remove-item?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -128,7 +128,18 @@ cmdlet interprets the subject of the search to be a file that has no child items
 fails.
 
 > [!NOTE]
-> This behavior was fixed in Windows versions 1909 and up.
+> Starting in Windows version 1909, specifying the file type in the **Path** parameter when using
+> the **Recurse** parameter does recursively discover child items with the given file extension.
+>
+> In Windows version 1909 and later, the following statements will discover and remove the same
+> files:
+>
+> ```powershell
+> # Works in all versions of Windows:
+> Get-ChildItem -Path * -Include *.csv -Recurse | Remove-Item
+> # Only correctly finds and removes nested CSV files in Windows 1909 and later:
+> Get-ChildItem -Path *.csv -Recurse | Remove-Item
+> ```
 
 ### Example 5: Delete subkeys recursively
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the `Remove-Item` documentation included a brief note for example 4 meant to indicate that the unusual construction of the command in the example:

```powershell
Get-ChildItem * -Include *.csv -Recurse | Remove-Item
```

Is no longer required in Windows version 1909 and later.

This change:

- Expands on the note to clarify the change in behavior and show how a user can write a more idiomatic statement in later versions of Windows to fulfill the same purpose.
- Fixes [AB#506233](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/506233)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
