### PR TITLE
(AB-506289) Fix overlocalization for `about_Module_Manifests`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,13 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 09/04/2025
+ms.date: 01/28/2026
+no-loc:
+- Windows PowerShell 5.1 Workflow
+- PowerShell Gallery
+- Author
+- Copyright
+- Description
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Module_Manifests
@@ -112,8 +118,8 @@ followed by a matrix that lists:
 
 - **Input type**: The object type that you can specify for this setting in the
   manifest.
-- **Required**: If this value is `Yes`, the setting is required both to import
-  the module and to publish it to the PowerShell Gallery. If it's `No`, it's
+- **Required**: If this value is "Yes", the setting is required both to import
+  the module and to publish it to the PowerShell Gallery. If it's "No", it's
   required for neither. If it's `PowerShell Gallery`, it's only required for
   publishing to the PowerShell Gallery.
 - **Value if unset**: The value this setting has when imported and not

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,13 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 09/04/2025
+ms.date: 01/28/2026
+no-loc:
+- Windows PowerShell 5.1 Workflow
+- PowerShell Gallery
+- Author
+- Copyright
+- Description
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Module_Manifests
@@ -112,8 +118,8 @@ followed by a matrix that lists:
 
 - **Input type**: The object type that you can specify for this setting in the
   manifest.
-- **Required**: If this value is `Yes`, the setting is required both to import
-  the module and to publish it to the PowerShell Gallery. If it's `No`, it's
+- **Required**: If this value is "Yes", the setting is required both to import
+  the module and to publish it to the PowerShell Gallery. If it's "No", it's
   required for neither. If it's `PowerShell Gallery`, it's only required for
   publishing to the PowerShell Gallery.
 - **Value if unset**: The value this setting has when imported and not

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,13 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 09/04/2025
+ms.date: 01/28/2026
+no-loc:
+- Windows PowerShell 5.1 Workflow
+- PowerShell Gallery
+- Author
+- Copyright
+- Description
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Module_Manifests
@@ -112,8 +118,8 @@ followed by a matrix that lists:
 
 - **Input type**: The object type that you can specify for this setting in the
   manifest.
-- **Required**: If this value is `Yes`, the setting is required both to import
-  the module and to publish it to the PowerShell Gallery. If it's `No`, it's
+- **Required**: If this value is "Yes", the setting is required both to import
+  the module and to publish it to the PowerShell Gallery. If it's "No", it's
   required for neither. If it's `PowerShell Gallery`, it's only required for
   publishing to the PowerShell Gallery.
 - **Value if unset**: The value this setting has when imported and not

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,13 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 09/04/2025
+ms.date: 01/28/2026
+no-loc:
+- Windows PowerShell 5.1 Workflow
+- PowerShell Gallery
+- Author
+- Copyright
+- Description
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Module_Manifests
@@ -112,8 +118,8 @@ followed by a matrix that lists:
 
 - **Input type**: The object type that you can specify for this setting in the
   manifest.
-- **Required**: If this value is `Yes`, the setting is required both to import
-  the module and to publish it to the PowerShell Gallery. If it's `No`, it's
+- **Required**: If this value is "Yes", the setting is required both to import
+  the module and to publish it to the PowerShell Gallery. If it's "No", it's
   required for neither. If it's `PowerShell Gallery`, it's only required for
   publishing to the PowerShell Gallery.
 - **Value if unset**: The value this setting has when imported and not


### PR DESCRIPTION
# PR Summary

Prior to this change, some keywords for the module manifest were overlocalized because the keywords are also general language, like `Author` and `Description`.

This change:

- Adds a set of words and phrases not to localize to reduce confusion.
- Makes minor changes for clarity in localization.
- Fixes [AB#506289](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/506289)


## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
