### PR TITLE
docs: fix repeated word typo in how-updatable-help-works.md

### DIFF
--- a/reference/docs-conceptual/developer/help/how-updatable-help-works.md
+++ b/reference/docs-conceptual/developer/help/how-updatable-help-works.md
@@ -20,7 +20,7 @@ to update the help files for a module in a particular UI culture.
 
 1. `Update-Help` compares the version number of the help files for the specified UI culture in the
    remote and local HelpInfo XML files for the module. If the version number on the remote file is
-   greater than version number on the local file, or if the there is no local HelpInfo XML file for
+   greater than version number on the local file, or if there is no local HelpInfo XML file for
    the module, `Update-Help` prepares to download new help files.
 
 1. `Update-Help` selects the CAB file for the module from the location specified by the
@@ -52,7 +52,7 @@ files for a module in a file share that's specified by the **DestinationPath** p
 
 1. `Save-Help` compares the version number of the help files for the specified UI culture in the
    remote and local HelpInfo XML files for the module. If the version number on the remote file is
-   greater than version number on the local file, or if the there is no local HelpInfo XML file for
+   greater than version number on the local file, or if there is no local HelpInfo XML file for
    the module in the **DestinationPath** directory, `Save-Help` prepares to download new help files.
 
 1. `Save-Help` selects the CAB file for the module from the location specified by the
@@ -76,7 +76,7 @@ files for a module in a file share that's specified by the **DestinationPath** p
 
 1. `Update-Help` compares the version number of the help files for the specified UI culture in the
    remote and local HelpInfo XML files for the module. If the version number on the remote file is
-   greater than version number on the local file, or if the there is no local HelpInfo XML file,
+   greater than version number on the local file, or if there is no local HelpInfo XML file,
    `Update-Help` prepares to install new help files.
 
 1. `Update-Help` selects the CAB file for the module from **SourcePath** directory. It uses the


### PR DESCRIPTION
# PR Summary

This PR fixes a repeated word typo ("the there") in the "How Updatable Help Works" conceptual documentation. The error was identified in three different locations within the description of the Update-Help and Save-Help processes.

- Fixes a typographical error: "if the there is" -> "if there is"
- Locations: Lines 23, 55, and 79 in how-updatable-help-works.md.

## PR Checklist

- [x] **Descriptive Title:** Title is a clear synopsis of the fix.
- [x] **Summary:** Summary describes the scope (typo fix) and intent.
- [x] **Contributor's Guide:** I have read the contributor's guide.
- [x] **Style:** This PR adheres to the PowerShell style guide.