### PR TITLE
docs(install): change brew install from cask to formula

### DIFF
--- a/reference/docs-conceptual/install/install-powershell-on-macos.md
+++ b/reference/docs-conceptual/install/install-powershell-on-macos.md
@@ -205,7 +205,7 @@ brew upgrade powershell
 If you installed PowerShell with Homebrew, use the following command to uninstall:
 
 ```sh
-brew uninstall --cask powershell
+brew uninstall powershell
 ```
 
 If you manually installed PowerShell 7, you must manually remove it. The following command removes


### PR DESCRIPTION
# PR Summary

Powershell will be moved from homebrew cask to formula, due to the official binaries not passing gatekeeper checks. This move will fix this, but installation is a bit different. => Installation command won't require `--cask` anymore. (https://github.com/Homebrew/homebrew-core/pull/268901)


