### PR TITLE
(AB-538621) Extend `Write-Host` note for non-primitive types

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/26/2023
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-host?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Host
@@ -35,7 +35,7 @@ a string to use to separate displayed objects. The particular result depends on 
 hosting PowerShell.
 
 > [!NOTE]
-> Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information` This allows
+> Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information`. This allows
 > you to use `Write-Host` to emit output to the information stream. This enables the **capture** or
 > **suppression** of data written using `Write-Host` while preserving backwards compatibility.
 >
@@ -261,8 +261,28 @@ cmdlet sends to it.
   separated by a single space. This can be overridden with the **Separator** parameter.
 
 - Non-primitive data types such as objects with properties can cause unexpected results and not
-  provide meaningful output. For example, `Write-Host @{a = 1; b = 2}` will print
-  `System.Collections.DictionaryEntry System.Collections.DictionaryEntry` to the host.
+  provide meaningful output. For example, `@{a = 1; b = 2} | Write-Host` will print
+  `System.Collections.Hashtable` to the host.
+
+  To work around this issue, you can manually create the string format you need with either string
+  interpolation or the format operator (`-f`). You can also pass the object to the
+  [Out-String](Out-String.md) command before passing it to `Write-Host`. The following snippet
+  shows examples of each approach:
+
+  ```powershell
+  $ht = @{a = 1; b = 2}
+  # String interpolation
+  $ht.Keys.ForEach({ "[$_, $($ht[$_])]" }) -join ' ' | Write-Host
+  # Format operator
+  "[{0}, {1}] [{2}, {3}]" -f @('a', $ht.a, 'b', $ht.b) | Write-Host
+  # Out-String
+  $ht | Out-String | Write-Host -NoNewline
+  ```
+
+  For more information about string interpolation, see the article
+  [Everything you wanted to know about variable substitution in strings](/powershell/scripting/learn/deep-dives/everything-about-string-substitutions).
+  For more information about the format operator, see
+  [about_Operators](../Microsoft.PowerShell.Core/About/about_Operators.md#format-operator--f).
 
 ## RELATED LINKS
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Write-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/26/2023
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-host?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Host
@@ -261,8 +261,28 @@ cmdlet sends to it.
   separated by a single space. This can be overridden with the **Separator** parameter.
 
 - Non-primitive data types such as objects with properties can cause unexpected results and not
-  provide meaningful output. For example, `Write-Host @{a = 1; b = 2}` will print
-  `System.Collections.DictionaryEntry System.Collections.DictionaryEntry` to the host.
+  provide meaningful output. For example, `@{a = 1; b = 2} | Write-Host` will print
+  `System.Collections.Hashtable` to the host.
+
+  To work around this issue, you can manually create the string format you need with either string
+  interpolation or the format operator (`-f`). You can also pass the object to the
+  [Out-String](Out-String.md) command before passing it to `Write-Host`. The following snippet
+  shows examples of each approach:
+
+  ```powershell
+  $ht = @{a = 1; b = 2}
+  # String interpolation
+  $ht.Keys.ForEach({ "[$_, $($ht[$_])]" }) -join ' ' | Write-Host
+  # Format operator
+  "[{0}, {1}] [{2}, {3}]" -f @('a', $ht.a, 'b', $ht.b) | Write-Host
+  # Out-String
+  $ht | Out-String | Write-Host -NoNewline
+  ```
+
+  For more information about string interpolation, see the article
+  [Everything you wanted to know about variable substitution in strings](/powershell/scripting/learn/deep-dives/everything-about-string-substitutions).
+  For more information about the format operator, see
+  [about_Operators](../Microsoft.PowerShell.Core/About/about_Operators.md#format-operator--f).
 
 ## RELATED LINKS
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Write-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/26/2023
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-host?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Host
@@ -35,7 +35,7 @@ a string to use to separate displayed objects. The particular result depends on 
 hosting PowerShell.
 
 > [!NOTE]
-> Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information` This allows
+> Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information`. This allows
 > you to use `Write-Host` to emit output to the information stream. This enables the **capture** or
 > **suppression** of data written using `Write-Host` while preserving backwards compatibility.
 >
@@ -261,8 +261,28 @@ cmdlet sends to it.
   separated by a single space. This can be overridden with the **Separator** parameter.
 
 - Non-primitive data types such as objects with properties can cause unexpected results and not
-  provide meaningful output. For example, `Write-Host @{a = 1; b = 2}` will print
-  `System.Collections.DictionaryEntry System.Collections.DictionaryEntry` to the host.
+  provide meaningful output. For example, `@{a = 1; b = 2} | Write-Host` will print
+  `System.Collections.Hashtable` to the host.
+
+  To work around this issue, you can manually create the string format you need with either string
+  interpolation or the format operator (`-f`). You can also pass the object to the
+  [Out-String](Out-String.md) command before passing it to `Write-Host`. The following snippet
+  shows examples of each approach:
+
+  ```powershell
+  $ht = @{a = 1; b = 2}
+  # String interpolation
+  $ht.Keys.ForEach({ "[$_, $($ht[$_])]" }) -join ' ' | Write-Host
+  # Format operator
+  "[{0}, {1}] [{2}, {3}]" -f @('a', $ht.a, 'b', $ht.b) | Write-Host
+  # Out-String
+  $ht | Out-String | Write-Host -NoNewline
+  ```
+
+  For more information about string interpolation, see the article
+  [Everything you wanted to know about variable substitution in strings](/powershell/scripting/learn/deep-dives/everything-about-string-substitutions).
+  For more information about the format operator, see
+  [about_Operators](../Microsoft.PowerShell.Core/About/about_Operators.md#format-operator--f).
 
 ## RELATED LINKS
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Write-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/26/2023
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-host?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Host
@@ -35,7 +35,7 @@ a string to use to separate displayed objects. The particular result depends on 
 hosting PowerShell.
 
 > [!NOTE]
-> Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information` This allows
+> Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information`. This allows
 > you to use `Write-Host` to emit output to the information stream. This enables the **capture** or
 > **suppression** of data written using `Write-Host` while preserving backwards compatibility.
 >
@@ -261,8 +261,28 @@ cmdlet sends to it.
   separated by a single space. This can be overridden with the **Separator** parameter.
 
 - Non-primitive data types such as objects with properties can cause unexpected results and not
-  provide meaningful output. For example, `Write-Host @{a = 1; b = 2}` will print
-  `System.Collections.DictionaryEntry System.Collections.DictionaryEntry` to the host.
+  provide meaningful output. For example, `@{a = 1; b = 2} | Write-Host` will print
+  `System.Collections.Hashtable` to the host.
+
+  To work around this issue, you can manually create the string format you need with either string
+  interpolation or the format operator (`-f`). You can also pass the object to the
+  [Out-String](Out-String.md) command before passing it to `Write-Host`. The following snippet
+  shows examples of each approach:
+
+  ```powershell
+  $ht = @{a = 1; b = 2}
+  # String interpolation
+  $ht.Keys.ForEach({ "[$_, $($ht[$_])]" }) -join ' ' | Write-Host
+  # Format operator
+  "[{0}, {1}] [{2}, {3}]" -f @('a', $ht.a, 'b', $ht.b) | Write-Host
+  # Out-String
+  $ht | Out-String | Write-Host -NoNewline
+  ```
+
+  For more information about string interpolation, see the article
+  [Everything you wanted to know about variable substitution in strings](/powershell/scripting/learn/deep-dives/everything-about-string-substitutions).
+  For more information about the format operator, see
+  [about_Operators](../Microsoft.PowerShell.Core/About/about_Operators.md#format-operator--f).
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

This PR fixes [AB#538621](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/538621) by extending the note about `Write-Host` having unexpected / not-useful output for objects by recommending approaches and showing a short example.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
