### PR TITLE
(AB-538639) Add note for destination exists to `Move-Item`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Move-Item.md
@@ -44,11 +44,10 @@ For example, it can move a file or subdirectory from one directory to another or
 subkey from one key to another. When you move an item, it is added to the new location and deleted
 from its original location.
 
-If the specified destination path resolves to an existing non-container item, or you're renaming
-and an item with the target name already exists, this cmdlet raises an error. To overwrite an
-existing item in these cases, specify the **Force** parameter. When the destination is an existing
-container (such as a directory), the item is moved into that container, if supported by the
-provider.
+If the specified destination path resolves to an existing non-container item, or you're moving and
+the target name already exists, this cmdlet raises an error. To overwrite an existing item, use the
+**Force** parameter. When the destination is an existing container (such as a directory), the item
+is moved into that container, if supported by the provider.
 
 ## EXAMPLES
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Move-Item.md
@@ -44,11 +44,10 @@ For example, it can move a file or subdirectory from one directory to another or
 subkey from one key to another. When you move an item, it is added to the new location and deleted
 from its original location.
 
-If the specified destination path resolves to an existing non-container item, or you're renaming
-and an item with the target name already exists, this cmdlet raises an error. To overwrite an
-existing item in these cases, specify the **Force** parameter. When the destination is an existing
-container (such as a directory), the item is moved into that container, if supported by the
-provider.
+If the specified destination path resolves to an existing non-container item, or you're moving and
+the target name already exists, this cmdlet raises an error. To overwrite an existing item, use the
+**Force** parameter. When the destination is an existing container (such as a directory), the item
+is moved into that container, if supported by the provider.
 
 ## EXAMPLES
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Move-Item.md
@@ -44,11 +44,10 @@ For example, it can move a file or subdirectory from one directory to another or
 subkey from one key to another. When you move an item, it is added to the new location and deleted
 from its original location.
 
-If the specified destination path resolves to an existing non-container item, or you're renaming
-and an item with the target name already exists, this cmdlet raises an error. To overwrite an
-existing item in these cases, specify the **Force** parameter. When the destination is an existing
-container (such as a directory), the item is moved into that container, if supported by the
-provider.
+If the specified destination path resolves to an existing non-container item, or you're moving and
+the target name already exists, this cmdlet raises an error. To overwrite an existing item, use the
+**Force** parameter. When the destination is an existing container (such as a directory), the item
+is moved into that container, if supported by the provider.
 
 ## EXAMPLES
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Move-Item.md
@@ -44,10 +44,10 @@ For example, it can move a file or subdirectory from one directory to another or
 subkey from one key to another. When you move an item, it is added to the new location and deleted
 from its original location.
 
-If the specified destination path resolves to an existing non-container item, or you're renaming
-and an item with the target name already exists, this cmdlet raises an error. To overwrite an
-existing item in these cases, specify the **Force** parameter. When the destination is an existing
-container (such as a directory), the item is moved into that container, if supported by the
+If the specified destination path resolves to an existing non-container item, or you're moving and
+the target name already exists, this cmdlet raises an error. To overwrite an existing item, use the
+**Force** parameter. When the destination is an existing container (such as a directory), the item
+is moved into that container, if supported by the provider.
 provider.
 
 ## EXAMPLES


### PR DESCRIPTION
# PR Summary

This change fixes [AB#538639](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/538639) by noting that the cmdlet fails if the destination item already exists and directs the reader to use the `-Force` parameter.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
