### PR TITLE
(AB-538640) Clarify behavior of `Rename-Item` when new name item exists

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/18/2026
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/rename-item?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -39,6 +39,10 @@ content of the item being renamed.
 
 You can't use `Rename-Item` to move an item, such as by specifying a path together with the new
 name. To move and rename an item, use the `Move-Item` cmdlet.
+
+You can't use `Rename-Item` to replace an existing item, such as renaming `log_new.txt` to
+`log_current.txt` when `log_current.txt` already exists. To replace an existing item, use the
+`Move-Item` cmdlet with the **Force** parameter.
 
 ## EXAMPLES
 
@@ -152,7 +156,8 @@ or read-only aliases or variables. The cmdlet can't change constant aliases or v
 Implementation varies from provider to provider. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-Even using the **Force** parameter, the cmdlet can't override security restrictions.
+Even using the **Force** parameter, the cmdlet can't override security restrictions or replace an
+existing item at the destination name specified by **NewName**.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.4/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Rename-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/18/2026
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/rename-item?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -38,6 +38,10 @@ content of the item being renamed.
 
 You can't use `Rename-Item` to move an item, such as by specifying a path together with the new
 name. To move and rename an item, use the `Move-Item` cmdlet.
+
+You can't use `Rename-Item` to replace an existing item, such as renaming `log_new.txt` to
+`log_current.txt` when `log_current.txt` already exists. To replace an existing item, use the
+`Move-Item` cmdlet with the **Force** parameter.
 
 ## EXAMPLES
 
@@ -151,7 +155,8 @@ or read-only aliases or variables. The cmdlet can't change constant aliases or v
 Implementation varies from provider to provider. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-Even using the **Force** parameter, the cmdlet can't override security restrictions.
+Even using the **Force** parameter, the cmdlet can't override security restrictions or replace an
+existing item at the destination name specified by **NewName**.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.5/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Rename-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/18/2026
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/rename-item?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -38,6 +38,10 @@ content of the item being renamed.
 
 You can't use `Rename-Item` to move an item, such as by specifying a path together with the new
 name. To move and rename an item, use the `Move-Item` cmdlet.
+
+You can't use `Rename-Item` to replace an existing item, such as renaming `log_new.txt` to
+`log_current.txt` when `log_current.txt` already exists. To replace an existing item, use the
+`Move-Item` cmdlet with the **Force** parameter.
 
 ## EXAMPLES
 
@@ -151,7 +155,8 @@ or read-only aliases or variables. The cmdlet can't change constant aliases or v
 Implementation varies from provider to provider. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-Even using the **Force** parameter, the cmdlet can't override security restrictions.
+Even using the **Force** parameter, the cmdlet can't override security restrictions or replace an
+existing item at the destination name specified by **NewName**.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.6/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Rename-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/18/2026
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/rename-item?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -38,6 +38,10 @@ content of the item being renamed.
 
 You can't use `Rename-Item` to move an item, such as by specifying a path together with the new
 name. To move and rename an item, use the `Move-Item` cmdlet.
+
+You can't use `Rename-Item` to replace an existing item, such as renaming `log_new.txt` to
+`log_current.txt` when `log_current.txt` already exists. To replace an existing item, use the
+`Move-Item` cmdlet with the **Force** parameter.
 
 ## EXAMPLES
 
@@ -151,7 +155,8 @@ or read-only aliases or variables. The cmdlet can't change constant aliases or v
 Implementation varies from provider to provider. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-Even using the **Force** parameter, the cmdlet can't override security restrictions.
+Even using the **Force** parameter, the cmdlet can't override security restrictions or replace an
+existing item at the destination name specified by **NewName**.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter


### PR DESCRIPTION
# PR Summary

This change fixes [AB#538640](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/538640) by clarifying the behavior of `Rename-Item` when the new name for the item already exists and that `Rename-Item -Force` doesn't replace the existing item.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
