### PR TITLE
(AB-538641) Clarify `Expand-Archive` only applies to zip files

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 10/06/2023
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Expand-Archive
@@ -11,7 +11,7 @@ title: Expand-Archive
 # Expand-Archive
 
 ## SYNOPSIS
-Extracts files from a specified archive (zipped) file.
+Extracts files from a specified ZIP archive file.
 
 ## SYNTAX
 
@@ -34,6 +34,13 @@ Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-Wh
 The `Expand-Archive` cmdlet extracts files from a specified zipped archive file to a specified
 destination folder. An archive file allows multiple files to be packaged, and optionally compressed,
 into a single zipped file for easier distribution and storage.
+
+This cmdlet only works with zip archives, which typically have the file extension `.zip`.
+
+The `Expand-Archive` cmdlet uses the **System.IO.Compression.ZipArchive** API to compress files.
+The API limits the maximum file size to 2GB. The .NET API works with files that conform to the
+official ZIP file format specification by PKWARE Inc. For more information, see
+[System.IO.Compression.ZipArchive](xref:System.IO.Compression.ZipArchive).
 
 ## EXAMPLES
 

--- a/reference/7.4/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/7.4/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 09/03/2024
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Expand-Archive
@@ -34,6 +34,8 @@ Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-Pa
 The `Expand-Archive` cmdlet extracts files from a specified zipped archive file to a specified
 destination folder. An archive file allows multiple files to be packaged, and optionally compressed,
 into a single zipped file for easier distribution and storage.
+
+This cmdlet only works with zip archives, which typically have the file extension `.zip`.
 
 The `Expand-Archive` cmdlet uses the **System.IO.Compression.ZipArchive** API to compress files.
 The API limits the maximum file size to 2GB. The .NET API works with files that conform to the

--- a/reference/7.5/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/7.5/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 10/06/2023
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Expand-Archive
@@ -11,7 +11,7 @@ title: Expand-Archive
 # Expand-Archive
 
 ## SYNOPSIS
-Extracts files from a specified archive (zipped) file.
+Extracts files from a specified ZIP archive file.
 
 ## SYNTAX
 
@@ -34,6 +34,13 @@ Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-Pa
 The `Expand-Archive` cmdlet extracts files from a specified zipped archive file to a specified
 destination folder. An archive file allows multiple files to be packaged, and optionally compressed,
 into a single zipped file for easier distribution and storage.
+
+This cmdlet only works with zip archives, which typically have the file extension `.zip`.
+
+The `Expand-Archive` cmdlet uses the **System.IO.Compression.ZipArchive** API to compress files.
+The API limits the maximum file size to 2GB. The .NET API works with files that conform to the
+official ZIP file format specification by PKWARE Inc. For more information, see
+[System.IO.Compression.ZipArchive](xref:System.IO.Compression.ZipArchive).
 
 ## EXAMPLES
 

--- a/reference/7.6/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/7.6/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 10/06/2023
+ms.date: 04/01/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Expand-Archive
@@ -34,6 +34,13 @@ Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-Pa
 The `Expand-Archive` cmdlet extracts files from a specified zipped archive file to a specified
 destination folder. An archive file allows multiple files to be packaged, and optionally compressed,
 into a single zipped file for easier distribution and storage.
+
+This cmdlet only works with zip archives, which typically have the file extension `.zip`.
+
+The `Expand-Archive` cmdlet uses the **System.IO.Compression.ZipArchive** API to compress files.
+The API limits the maximum file size to 2GB. The .NET API works with files that conform to the
+official ZIP file format specification by PKWARE Inc. For more information, see
+[System.IO.Compression.ZipArchive](xref:System.IO.Compression.ZipArchive).
 
 ## EXAMPLES
 


### PR DESCRIPTION
# PR Summary

This change fixes [AB#538641](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/538641) by clarifying that the `Expand-Archive` cmdlet only applies to `.zip` files. It also makes the description and synopsis consistent.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
