### PR TITLE
Fix syntax of hexadecimal-digits in chapter-02.md

### DIFF
--- a/reference/docs-conceptual/lang-spec/chapter-02.md
+++ b/reference/docs-conceptual/lang-spec/chapter-02.md
@@ -644,7 +644,7 @@ hexadecimal-integer-literal:
 
 hexadecimal-digits:
     hexadecimal-digit
-    hexadecimal-digit decimal-digits
+    hexadecimal-digit hexadecimal-digits
 
 hexadecimal-digit: one of
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f


### PR DESCRIPTION
# PR Summary

Fixes an error in the syntax for `hexadecimal-digits`:
`hexadecimal-digit decimal-digits` -> `hexadecimal-digit hexadecimal-digits`

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
