### PR TITLE
Fix output of example in everything-about-shouldprocess.md

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
@@ -443,7 +443,7 @@ This provides us a simpler prompt with fewer options.
 ```powershell
 Test-ShouldContinue
 
-Second
+OPERATION
 TARGET
 [Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"):
 ```


### PR DESCRIPTION
Correcting output of the `Test-ShouldContinue` example in the documentation.

# PR Summary

Given the parameters of `ShouldContinue`, the correct output here would be `OPERATION` and not `Second`

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
