### PR TITLE
Document System Lockdown mode in security features

### DIFF
--- a/reference/docs-conceptual/security/security-features.md
+++ b/reference/docs-conceptual/security/security-features.md
@@ -79,15 +79,16 @@ For more information about how PowerShell supports AppLocker and App Control, se
 
 ### System Lockdown mode
 
-System Lockdown mode is PowerShell's abstraction of the system-wide application control policy
+In PowerShell, System Lockdown mode is an abstraction of the system-wide application control policy
 enforced by Windows through App Control for Business or AppLocker. When an application control
 policy is active, PowerShell enters System Lockdown mode. In System Lockdown mode, the application
 control policy determines the language mode for each runspace.
 
-**Without System Lockdown mode, language mode does not propagate between runspaces.** Each
-runspace independently queries the Windows application control policy to determine its language
-mode. Setting the language mode on one runspace does not affect other runspaces. **Without an
-active application control policy, new runspaces default to `FullLanguage` mode.**
+> [!IMPORTANT]
+> Without System Lockdown mode, language mode doesn't propagate between runspaces. Each runspace
+> independently queries the Windows application control policy to determine its language mode.
+> Setting the language mode on one runspace doesn't affect other runspaces. Without an active
+> application control policy, new runspaces default to `FullLanguage` mode.
 
 ## Software Bill of Materials (SBOM)
 

--- a/reference/docs-conceptual/security/security-features.md
+++ b/reference/docs-conceptual/security/security-features.md
@@ -86,8 +86,8 @@ ConstrainedLanguage mode as the default for all runspaces.
 
 **Without SLM, language mode does not propagate between runspaces.** Each runspace independently
 queries the Windows application control policy to determine its language mode. Setting the language
-mode on one runspace does not affect other runspaces. Without an active application control policy,
-new runspaces default to FullLanguage mode.
+mode on one runspace does not affect other runspaces. **Without an active application control policy,
+new runspaces default to FullLanguage mode.**
 
 ## Software Bill of Materials (SBOM)
 

--- a/reference/docs-conceptual/security/security-features.md
+++ b/reference/docs-conceptual/security/security-features.md
@@ -77,17 +77,17 @@ system for Windows.
 For more information about how PowerShell supports AppLocker and App Control, see
 [Use App Control to secure PowerShell][10].
 
-### System Lockdown Mode
+### System Lockdown mode
 
-System Lockdown Mode (SLM) is PowerShell's abstraction of the system-wide application control
-policy enforced by Windows through App Control for Business or AppLocker. When Windows reports
-that an application control policy is active, PowerShell enters SLM and applies
-`ConstrainedLanguage` mode as the default for all runspaces.
+System Lockdown mode is PowerShell's abstraction of the system-wide application control policy
+enforced by Windows through App Control for Business or AppLocker. When an application control
+policy is active, PowerShell enters System Lockdown mode. In System Lockdown mode, the application
+control policy determines the language mode for each runspace.
 
-**Without SLM, language mode does not propagate between runspaces.** Each runspace independently
-queries the Windows application control policy to determine its language mode. Setting the language
-mode on one runspace does not affect other runspaces. **Without an active application control policy,
-new runspaces default to `FullLanguage` mode.**
+**Without System Lockdown mode, language mode does not propagate between runspaces.** Each
+runspace independently queries the Windows application control policy to determine its language
+mode. Setting the language mode on one runspace does not affect other runspaces. **Without an
+active application control policy, new runspaces default to `FullLanguage` mode.**
 
 ## Software Bill of Materials (SBOM)
 

--- a/reference/docs-conceptual/security/security-features.md
+++ b/reference/docs-conceptual/security/security-features.md
@@ -82,12 +82,12 @@ For more information about how PowerShell supports AppLocker and App Control, se
 System Lockdown Mode (SLM) is PowerShell's abstraction of the system-wide application control
 policy enforced by Windows through App Control for Business or AppLocker. When Windows reports
 that an application control policy is active, PowerShell enters SLM and applies
-ConstrainedLanguage mode as the default for all runspaces.
+`ConstrainedLanguage` mode as the default for all runspaces.
 
 **Without SLM, language mode does not propagate between runspaces.** Each runspace independently
 queries the Windows application control policy to determine its language mode. Setting the language
 mode on one runspace does not affect other runspaces. **Without an active application control policy,
-new runspaces default to FullLanguage mode.**
+new runspaces default to `FullLanguage` mode.**
 
 ## Software Bill of Materials (SBOM)
 

--- a/reference/docs-conceptual/security/security-features.md
+++ b/reference/docs-conceptual/security/security-features.md
@@ -77,6 +77,18 @@ system for Windows.
 For more information about how PowerShell supports AppLocker and App Control, see
 [Use App Control to secure PowerShell][10].
 
+### System Lockdown Mode
+
+System Lockdown Mode (SLM) is PowerShell's abstraction of the system-wide application control
+policy enforced by Windows through App Control for Business or AppLocker. When Windows reports
+that an application control policy is active, PowerShell enters SLM and applies
+ConstrainedLanguage mode as the default for all runspaces.
+
+**Without SLM, language mode does not propagate between runspaces.** Each runspace independently
+queries the Windows application control policy to determine its language mode. Setting the language
+mode on one runspace does not affect other runspaces. Without an active application control policy,
+new runspaces default to FullLanguage mode.
+
 ## Software Bill of Materials (SBOM)
 
 Beginning with PowerShell 7.2, all install packages contain a Software Bill of Materials (SBOM). The


### PR DESCRIPTION
Added information about System Lockdown mode and its impact on language modes in PowerShell.

# PR Summary

This pull request adds documentation about System Lockdown mode to the PowerShell security features conceptual documentation. It explains how System Lockdown mode works with Windows application control policies and clarifies how language mode behaves for PowerShell runspaces.

New documentation for application control:

* Added a section describing System Lockdown mode and explaining that PowerShell enters it when an application control policy is active
* Clarified that in System Lockdown mode, the application control policy determines the language mode for each runspace
* Clarified that without System Lockdown mode, language mode does not propagate between runspaces and that, without an active application control policy, new runspaces default to `FullLanguage` mode

## PR Checklist



- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].



[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide