### PR TITLE
Remove ms.product metadata from index.md

### DIFF
--- a/reference/module/index.md
+++ b/reference/module/index.md
@@ -9,7 +9,6 @@ ms.author: sewhee
 ms.date: 05/05/2026
 ms.devlang: powershell
 ms.manager: sewhee
-ms.product: powershell
 ms.topic: landing-page
 quickFilterColumn1: powershell-7.4,windowsserver2025-ps
 quickFilterColumn2: azps-15.6.0,sqlserver-ps


### PR DESCRIPTION
I assume this was supposed to be `ms.prod` originally. But should be covered by  [ms.service in the docfx.json file](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/90c9c7a6208443e57eea1d4e3b3b42ddc1915543/reference/docfx.json#L133) anyway.