### PR TITLE
Invoke-WmiMethod: Corrects a typo - a "Invoke-CimCommand" cmdlet doesn't exist

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -188,7 +188,7 @@ Invoke-WmiMethod @invokeWmiMethodSplat
 ### -ArgumentList
 
 Specifies the parameters to pass to the called method. The value of this parameter must be an array
-of objects, and they must appear in the order required by the called method. The `Invoke-CimCommand`
+of objects, and they must appear in the order required by the called method. The `Invoke-CimMethod`
 cmdlet does not have these limitations.
 
 To determine the order in which to list those objects, run the `GetMethodParameters()` method on the


### PR DESCRIPTION
# PR Summary

Corrects a typo - a "Invoke-CimCommand" cmdlet doesn't exist

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
