### PR TITLE
Added missing headings for Start-Process Default parameter set

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Start-Process.md
@@ -18,6 +18,8 @@ Starts one or more processes on the local computer.
 
 ## SYNTAX
 
+### Default (Default)
+
 ```
 Start-Process [-FilePath] <string> [[-ArgumentList] <string[]>]
  [-Credential <pscredential>] [-WorkingDirectory <string>] [-LoadUserProfile]

--- a/reference/7.5/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Start-Process.md
@@ -18,6 +18,8 @@ Starts one or more processes on the local computer.
 
 ## SYNTAX
 
+### Default (Default)
+
 ```
 Start-Process [-FilePath] <string> [[-ArgumentList] <string[]>]
  [-Credential <pscredential>] [-WorkingDirectory <string>] [-LoadUserProfile]

--- a/reference/7.6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Start-Process.md
@@ -18,6 +18,8 @@ Starts one or more processes on the local computer.
 
 ## SYNTAX
 
+### Default (Default)
+
 ```
 Start-Process [-FilePath] <string> [[-ArgumentList] <string[]>]
  [-Credential <pscredential>] [-WorkingDirectory <string>] [-LoadUserProfile]

--- a/reference/7.7/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.7/Microsoft.PowerShell.Management/Start-Process.md
@@ -18,6 +18,8 @@ Starts one or more processes on the local computer.
 
 ## SYNTAX
 
+### Default (Default)
+
 ```
 Start-Process [-FilePath] <string> [[-ArgumentList] <string[]>]
  [-Credential <pscredential>] [-WorkingDirectory <string>] [-LoadUserProfile]


### PR DESCRIPTION
# PR Summary

In the PowerShell 7.4, 7.5, 7.6, and 7.7 docs for the Start-Process cmdlet, there is no heading for the Default parameter set under the Syntax heading. As a result, the syntax block for the Default parameter set is entirely omitted from both the learn.microsoft.com page and the Get-Help output for this cmdlet. This change fixes the problem by adding the missing headings to the relevant markdown files.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
