### PR TITLE
Fixes #13184 - Fix .foreach() example so it works in 5.1

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 description: Describes arrays, which are data structures designed to store collections of items.
 Locale: en-US
-ms.date: 03/24/2026
+ms.date: 07/29/2026
 no-loc: [Count, Length, LongLength, Rank, ForEach, Clear, Default, First, Last, SkipUntil, Until, Split, Tuple]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -593,7 +593,7 @@ Consider the following example where the object `$myObject` has a property with
 single value and a property containing an array of 11 integers.
 
 ```powershell
-$myObject = [pscustomobject]@{
+$myObject = @{
     singleValue = 'Hello'
     arrayValue  = @(0..10)
 }


### PR DESCRIPTION
# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This change fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->
Fix `.foreach()` example so it works in 5.1. The `.foreach()` and `.where()` methods were added in PowerShell 4.0. However, they don't apply to all object types. At some point after PowerShell 6.0, the methods were extended to more object types (specifically `[pscustomobject]` in this example).

- Fixes [AB#601474](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/601474)
- Fixes #13184

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide