### PR TITLE
Revert incorrect Copilot suggestions of PR #13205 and fix

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/09/2026
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -227,8 +227,7 @@ Accept wildcard characters: True
 
 ### -PassThru
 
-By default, this cmdlet doesn't generate any output. When you use this parameter the command returns
-an object that represents the process.
+Returns an object that represents the process. By default, this cmdlet does not generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -305,18 +304,16 @@ Windows PowerShell includes the following aliases for `Stop-Process`:
 - `kill`
 - `spps`
 
-The `Stop-Process` cmdlet doesn't wait for the process to exit. There are two ways to wait for the
-process to exit:
-
-- Use the **PassThru** parameter with `Stop-Process` and periodically check the **HasExited**
-  property of returned **Process** object
-- Call `Wait-Process` for the process you stopped to wait for the process to exit
+The `Stop-Process` cmdlet executes asynchronously. After calling the `Stop-Process` cmdlet, you can
+call the `Wait-Process` cmdlet to wait for the process to exit, or check the **HasExited** property
+of the **Process** object that can be an input, or output if using the **PassThru** parameter of the
+`Stop-Process` cmdlet, to determine if the process has exited.
 
 You can also use the properties and methods of the Windows Management Instrumentation (WMI)
 **Win32_Process** object in Windows PowerShell. For more information, see `Get-CimInstance` and
 the WMI SDK.
 
-When stopping processes, realize that stopping a process can stop process and services that depend
+When stopping processes, realize that stopping a process can stop processes and services that depend
 on the process. In an extreme case, stopping a process can stop Windows.
 
 This cmdlet is implemented using the **Kill** method of the **System.Diagnostics.Process** class.

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/05/2023
+ms.date: 08/10/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:

--- a/reference/7.4/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/09/2026
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -227,8 +227,7 @@ Accept wildcard characters: True
 
 ### -PassThru
 
-By default, this cmdlet doesn't generate any output. When you use this parameter the command returns
-an object that represents the process.
+Returns an object that represents the process. By default, this cmdlet does not generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -307,18 +306,16 @@ PowerShell includes the following aliases for `Stop-Process`:
 - Windows:
   - `kill`
 
-The `Stop-Process` cmdlet doesn't wait for the process to exit. There are two ways to wait for the
-process to exit:
-
-- Use the **PassThru** parameter with `Stop-Process` and periodically check the **HasExited**
-  property of returned **Process** object
-- Call `Wait-Process` for the process you stopped to wait for the process to exit
+The `Stop-Process` cmdlet executes asynchronously. After calling the `Stop-Process` cmdlet, you can
+call the `Wait-Process` cmdlet to wait for the process to exit, or check the **HasExited** property
+of the **Process** object that can be an input, or output if using the **PassThru** parameter of the
+`Stop-Process` cmdlet, to determine if the process has exited.
 
 You can also use the properties and methods of the Windows Management Instrumentation (WMI)
 **Win32_Process** object in Windows PowerShell. For more information, see `Get-CimInstance` and
 the WMI SDK.
 
-When stopping processes, realize that stopping a process can stop process and services that depend
+When stopping processes, realize that stopping a process can stop processes and services that depend
 on the process. In an extreme case, stopping a process can stop Windows.
 
 This cmdlet is implemented using the **Kill** method of the **System.Diagnostics.Process** class.

--- a/reference/7.4/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/05/2023
+ms.date: 08/10/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:

--- a/reference/7.5/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/05/2023
+ms.date: 08/10/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:

--- a/reference/7.5/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/09/2026
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -226,8 +226,7 @@ Accept wildcard characters: True
 
 ### -PassThru
 
-By default, this cmdlet doesn't generate any output. When you use this parameter the command returns
-an object that represents the process.
+Returns an object that represents the process. By default, this cmdlet does not generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -306,18 +305,16 @@ PowerShell includes the following aliases for `Stop-Process`:
 - Windows:
   - `kill`
 
-The `Stop-Process` cmdlet doesn't wait for the process to exit. There are two ways to wait for the
-process to exit:
-
-- Use the **PassThru** parameter with `Stop-Process` and periodically check the **HasExited**
-  property of returned **Process** object
-- Call `Wait-Process` for the process you stopped to wait for the process to exit
+The `Stop-Process` cmdlet executes asynchronously. After calling the `Stop-Process` cmdlet, you can
+call the `Wait-Process` cmdlet to wait for the process to exit, or check the **HasExited** property
+of the **Process** object that can be an input, or output if using the **PassThru** parameter of the
+`Stop-Process` cmdlet, to determine if the process has exited.
 
 You can also use the properties and methods of the Windows Management Instrumentation (WMI)
 **Win32_Process** object in Windows PowerShell. For more information, see `Get-CimInstance` and
 the WMI SDK.
 
-When stopping processes, realize that stopping a process can stop process and services that depend
+When stopping processes, realize that stopping a process can stop processes and services that depend
 on the process. In an extreme case, stopping a process can stop Windows.
 
 This cmdlet is implemented using the **Kill** method of the **System.Diagnostics.Process** class.

--- a/reference/7.6/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/09/2026
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -226,8 +226,7 @@ Accept wildcard characters: True
 
 ### -PassThru
 
-By default, this cmdlet doesn't generate any output. When you use this parameter the command returns
-an object that represents the process.
+Returns an object that represents the process. By default, this cmdlet does not generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -306,18 +305,16 @@ PowerShell includes the following aliases for `Stop-Process`:
 - Windows:
   - `kill`
 
-The `Stop-Process` cmdlet doesn't wait for the process to exit. There are two ways to wait for the
-process to exit:
-
-- Use the **PassThru** parameter with `Stop-Process` and periodically check the **HasExited**
-  property of returned **Process** object
-- Call `Wait-Process` for the process you stopped to wait for the process to exit
+The `Stop-Process` cmdlet executes asynchronously. After calling the `Stop-Process` cmdlet, you can
+call the `Wait-Process` cmdlet to wait for the process to exit, or check the **HasExited** property
+of the **Process** object that can be an input, or output if using the **PassThru** parameter of the
+`Stop-Process` cmdlet, to determine if the process has exited.
 
 You can also use the properties and methods of the Windows Management Instrumentation (WMI)
 **Win32_Process** object in Windows PowerShell. For more information, see `Get-CimInstance` and
 the WMI SDK.
 
-When stopping processes, realize that stopping a process can stop process and services that depend
+When stopping processes, realize that stopping a process can stop processes and services that depend
 on the process. In an extreme case, stopping a process can stop Windows.
 
 This cmdlet is implemented using the **Kill** method of the **System.Diagnostics.Process** class.

--- a/reference/7.6/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/05/2023
+ms.date: 08/10/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:

--- a/reference/7.7/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.7/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/09/2026
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:
@@ -226,8 +226,7 @@ Accept wildcard characters: True
 
 ### -PassThru
 
-By default, this cmdlet doesn't generate any output. When you use this parameter the command returns
-an object that represents the process.
+Returns an object that represents the process. By default, this cmdlet does not generate any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -306,18 +305,16 @@ PowerShell includes the following aliases for `Stop-Process`:
 - Windows:
   - `kill`
 
-The `Stop-Process` cmdlet doesn't wait for the process to exit. There are two ways to wait for the
-process to exit:
-
-- Use the **PassThru** parameter with `Stop-Process` and periodically check the **HasExited**
-  property of returned **Process** object
-- Call `Wait-Process` for the process you stopped to wait for the process to exit
+The `Stop-Process` cmdlet executes asynchronously. After calling the `Stop-Process` cmdlet, you can
+call the `Wait-Process` cmdlet to wait for the process to exit, or check the **HasExited** property
+of the **Process** object that can be an input, or output if using the **PassThru** parameter of the
+`Stop-Process` cmdlet, to determine if the process has exited.
 
 You can also use the properties and methods of the Windows Management Instrumentation (WMI)
 **Win32_Process** object in Windows PowerShell. For more information, see `Get-CimInstance` and
 the WMI SDK.
 
-When stopping processes, realize that stopping a process can stop process and services that depend
+When stopping processes, realize that stopping a process can stop processes and services that depend
 on the process. In an extreme case, stopping a process can stop Windows.
 
 This cmdlet is implemented using the **Kill** method of the **System.Diagnostics.Process** class.

--- a/reference/7.7/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.7/Microsoft.PowerShell.Management/Stop-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 01/05/2023
+ms.date: 08/10/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 aliases:


### PR DESCRIPTION
# PR Summary

Reverted incorrect Copilot suggestions applied by the reviewer of [PR #13205](https://github.com/MicrosoftDocs/PowerShell-Docs/pull/13205), where the suggested edit says to check Process.HasExited periodically to wait for the process to exit, which is an incorrect and hacky usage of it, and then lists the correct way through `Wait-Process` as the second option.

For example, this is the correct way to wait for processes, which is trough `Wait-Process`, and the correct usage of Process.HasExited, which is just to determine if the process has exited.
```powershell
Stop-Process -PassThru -Name mspaint | Wait-Process -PassThru -Timeout 10 | Where-Object {-not $_.HasExited}
```


Also clarified where the Process object comes from as the suggestion's original intentions seemed to be and did a minor grammatical fix.

Please be mindful of LLM output, as it's only a lossy mimicry of what humans do.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
