### PR TITLE
Wait-Process uses Exited not WaitForExit

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Wait-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 08/19/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/wait-process?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Wait-Process
@@ -182,7 +182,7 @@ This cmdlet returns no output.
 
 ## NOTES
 
-- This cmdlet uses the **WaitForExit** method of the **System.Diagnostics.Process** class.
+- This cmdlet uses the **Exited** event of the **System.Diagnostics.Process** class.
 
 - Unlike `Start-Process -Wait`, `Wait-Process` only waits for the processes identified.
   `Start-Process -Wait` waits for the process tree (the process and all its descendants) to exit

--- a/reference/7.4/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Wait-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/18/2023
+ms.date: 08/19/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/wait-process?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Wait-Process
@@ -226,7 +226,7 @@ The cmdlet returns process objects when you use the **PassThru** parameter.
 
 ## NOTES
 
-- This cmdlet uses the **WaitForExit** method of the **System.Diagnostics.Process** class.
+- This cmdlet uses the **Exited** event of the **System.Diagnostics.Process** class.
 
 - Unlike `Start-Process -Wait`, `Wait-Process` only waits for the processes identified.
   `Start-Process -Wait` waits for the process tree (the process and all its descendants) to exit

--- a/reference/7.5/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Wait-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/18/2023
+ms.date: 08/19/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/wait-process?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Wait-Process
@@ -226,7 +226,7 @@ The cmdlet returns process objects when you use the **PassThru** parameter.
 
 ## NOTES
 
-- This cmdlet uses the **WaitForExit** method of the **System.Diagnostics.Process** class.
+- This cmdlet uses the **Exited** event of the **System.Diagnostics.Process** class.
 
 - Unlike `Start-Process -Wait`, `Wait-Process` only waits for the processes identified.
   `Start-Process -Wait` waits for the process tree (the process and all its descendants) to exit

--- a/reference/7.6/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Wait-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/18/2023
+ms.date: 08/19/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/wait-process?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Wait-Process
@@ -226,7 +226,7 @@ The cmdlet returns process objects when you use the **PassThru** parameter.
 
 ## NOTES
 
-- This cmdlet uses the **WaitForExit** method of the **System.Diagnostics.Process** class.
+- This cmdlet uses the **Exited** event of the **System.Diagnostics.Process** class.
 
 - Unlike `Start-Process -Wait`, `Wait-Process` only waits for the processes identified.
   `Start-Process -Wait` waits for the process tree (the process and all its descendants) to exit

--- a/reference/7.7/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/7.7/Microsoft.PowerShell.Management/Wait-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/18/2023
+ms.date: 08/19/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/wait-process?view=powershell-7.7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Wait-Process
@@ -226,7 +226,7 @@ The cmdlet returns process objects when you use the **PassThru** parameter.
 
 ## NOTES
 
-- This cmdlet uses the **WaitForExit** method of the **System.Diagnostics.Process** class.
+- This cmdlet uses the **Exited** event of the **System.Diagnostics.Process** class.
 
 - Unlike `Start-Process -Wait`, `Wait-Process` only waits for the processes identified.
   `Start-Process -Wait` waits for the process tree (the process and all its descendants) to exit


### PR DESCRIPTION
# PR Summary

Wait-Process uses the Exited event, not the WaitForExit method, of the Process class.

Checked the source code of [Powershell v7.7.0 preview 3](https://github.com/PowerShell/PowerShell/blob/v7.7.0-preview.3/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs#L979), [Powershell v7.6.5](https://github.com/PowerShell/PowerShell/blob/v7.6.5/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs#L979), [Powershell v6.2.7](https://github.com/PowerShell/PowerShell/blob/v6.2.7/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs#L1000) and tested on Windows Powershell v5.1 as it has different behavior to WaitForExit when waiting for processes running on a different user, as they may have fields blanked/zeroed provably as a bug, and also the process object's EnableRaisingEvents becomes true.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
