### PR TITLE
Document that the Windows PowerShell PSModulePath fixup applies only to direct child processes

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -1,7 +1,7 @@
 ---
 description: The PSModulePath environment variable contains a list of folder locations that are searched to find modules and resources.
 Locale: en-US
-ms.date: 10/14/2024
+ms.date: 08/25/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_PSModulePath?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_PSModulePath
@@ -50,6 +50,18 @@ startup:
 The **CurrentUser** module path is prefixed only if the User scope
 `$Env:PSModulePath` doesn't exist. Otherwise, the User scope
 `$Env:PSModulePath` is used as defined.
+
+> [!NOTE]
+> When Windows PowerShell runs in a process tree that contains PowerShell 7,
+> it can inherit a `PSModulePath` value that includes PowerShell 7 module
+> paths. PowerShell 7 removes its own module paths when it starts Windows
+> PowerShell directly, but not when Windows PowerShell is started through an
+> intermediate process. Inherited PowerShell 7 module paths precede the
+> Windows PowerShell system module path, which can cause shared module names,
+> such as `Microsoft.PowerShell.Utility`, to resolve to PowerShell 7 module
+> versions that Windows PowerShell can't load. This breaks module
+> autoloading. For more information and workarounds, see the
+> [PowerShell 7 version of this article][04].
 
 ## Module search behavior
 
@@ -119,3 +131,4 @@ $key.SetValue('PSModulePath',$path,[Microsoft.Win32.RegistryValueKind]::ExpandSt
 [01]: about_Modules.md
 [02]: /powershell/module/microsoft.powershell.core/about/about_windows_powershell_compatibility
 [03]: xref:Microsoft.PowerShell.Core.Import-Module
+[04]: /powershell/module/microsoft.powershell.core/about/about_psmodulepath?view=powershell-7.6&preserve-view=true

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -156,6 +156,9 @@ example:
   child process:
 
   ```python
+  import os
+  import subprocess
+
   env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
   subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
   ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -1,7 +1,7 @@
 ---
 description: The PSModulePath environment variable contains a list of folder locations that are searched to find modules and resources.
 Locale: en-US
-ms.date: 10/14/2024
+ms.date: 08/25/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_PSModulePath?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_PSModulePath
@@ -120,6 +120,45 @@ following modifications:
 The PS7 paths are removed so that PS7 modules don't get loaded in Windows
 PowerShell. The `WinPSModulePath` value is used when starting Windows
 PowerShell.
+
+This modification only applies to Windows PowerShell processes that
+PowerShell 7 starts directly. When Windows PowerShell is started through an
+intermediate process, such as a `cmd.exe` or Python process that PowerShell 7
+launched, the intermediate process inherits the unmodified
+`$Env:PSModulePath` of PowerShell 7 and passes it on to its own child
+processes. Windows PowerShell started this way keeps the inherited
+PowerShell 7 module paths. Because those paths precede the Windows PowerShell
+system module path, Windows PowerShell can resolve shared module names, such
+as `Microsoft.PowerShell.Utility`, to PowerShell 7 module versions that it
+can't load. This breaks module autoloading, and the cmdlets from those
+modules fail with a `CommandNotFoundException` error.
+
+To start Windows PowerShell from an intermediate process with the correct
+module paths, remove `PSModulePath` from the environment of the child
+process. Windows PowerShell then constructs its default value at startup. For
+example:
+
+- In PowerShell 7.4 and higher, use the **Environment** parameter of
+  `Start-Process` to remove the variable from the environment of the
+  intermediate process:
+
+  ```powershell
+  Start-Process python harness.py -Environment @{ PSModulePath = $null }
+  ```
+
+- In `cmd.exe`, clear the variable before starting Windows PowerShell:
+
+  ```cmd
+  cmd /c "set PSModulePath=&& powershell.exe -File script.ps1"
+  ```
+
+- In Python, remove the variable from the environment that you pass to the
+  child process:
+
+  ```python
+  env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
+  subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
+  ```
 
 ### Starting PowerShell 7 from Windows PowerShell
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -1,7 +1,7 @@
 ---
 description: The PSModulePath environment variable contains a list of folder locations that are searched to find modules and resources.
 Locale: en-US
-ms.date: 10/14/2024
+ms.date: 08/25/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_PSModulePath?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_PSModulePath
@@ -120,6 +120,45 @@ following modifications:
 The PS7 paths are removed so that PS7 modules don't get loaded in Windows
 PowerShell. The `WinPSModulePath` value is used when starting Windows
 PowerShell.
+
+This modification only applies to Windows PowerShell processes that
+PowerShell 7 starts directly. When Windows PowerShell is started through an
+intermediate process, such as a `cmd.exe` or Python process that PowerShell 7
+launched, the intermediate process inherits the unmodified
+`$Env:PSModulePath` of PowerShell 7 and passes it on to its own child
+processes. Windows PowerShell started this way keeps the inherited
+PowerShell 7 module paths. Because those paths precede the Windows PowerShell
+system module path, Windows PowerShell can resolve shared module names, such
+as `Microsoft.PowerShell.Utility`, to PowerShell 7 module versions that it
+can't load. This breaks module autoloading, and the cmdlets from those
+modules fail with a `CommandNotFoundException` error.
+
+To start Windows PowerShell from an intermediate process with the correct
+module paths, remove `PSModulePath` from the environment of the child
+process. Windows PowerShell then constructs its default value at startup. For
+example:
+
+- In PowerShell 7.4 and higher, use the **Environment** parameter of
+  `Start-Process` to remove the variable from the environment of the
+  intermediate process:
+
+  ```powershell
+  Start-Process python harness.py -Environment @{ PSModulePath = $null }
+  ```
+
+- In `cmd.exe`, clear the variable before starting Windows PowerShell:
+
+  ```cmd
+  cmd /c "set PSModulePath=&& powershell.exe -File script.ps1"
+  ```
+
+- In Python, remove the variable from the environment that you pass to the
+  child process:
+
+  ```python
+  env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
+  subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
+  ```
 
 ### Starting PowerShell 7 from Windows PowerShell
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -156,6 +156,9 @@ example:
   child process:
 
   ```python
+  import os
+  import subprocess
+
   env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
   subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
   ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -156,6 +156,9 @@ example:
   child process:
 
   ```python
+  import os
+  import subprocess
+
   env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
   subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
   ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -1,7 +1,7 @@
 ---
 description: The PSModulePath environment variable contains a list of folder locations that are searched to find modules and resources.
 Locale: en-US
-ms.date: 10/14/2024
+ms.date: 08/25/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_PSModulePath?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_PSModulePath
@@ -120,6 +120,45 @@ following modifications:
 The PS7 paths are removed so that PS7 modules don't get loaded in Windows
 PowerShell. The `WinPSModulePath` value is used when starting Windows
 PowerShell.
+
+This modification only applies to Windows PowerShell processes that
+PowerShell 7 starts directly. When Windows PowerShell is started through an
+intermediate process, such as a `cmd.exe` or Python process that PowerShell 7
+launched, the intermediate process inherits the unmodified
+`$Env:PSModulePath` of PowerShell 7 and passes it on to its own child
+processes. Windows PowerShell started this way keeps the inherited
+PowerShell 7 module paths. Because those paths precede the Windows PowerShell
+system module path, Windows PowerShell can resolve shared module names, such
+as `Microsoft.PowerShell.Utility`, to PowerShell 7 module versions that it
+can't load. This breaks module autoloading, and the cmdlets from those
+modules fail with a `CommandNotFoundException` error.
+
+To start Windows PowerShell from an intermediate process with the correct
+module paths, remove `PSModulePath` from the environment of the child
+process. Windows PowerShell then constructs its default value at startup. For
+example:
+
+- In PowerShell 7.4 and higher, use the **Environment** parameter of
+  `Start-Process` to remove the variable from the environment of the
+  intermediate process:
+
+  ```powershell
+  Start-Process python harness.py -Environment @{ PSModulePath = $null }
+  ```
+
+- In `cmd.exe`, clear the variable before starting Windows PowerShell:
+
+  ```cmd
+  cmd /c "set PSModulePath=&& powershell.exe -File script.ps1"
+  ```
+
+- In Python, remove the variable from the environment that you pass to the
+  child process:
+
+  ```python
+  env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
+  subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
+  ```
 
 ### Starting PowerShell 7 from Windows PowerShell
 

--- a/reference/7.7/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.7/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -156,6 +156,9 @@ example:
   child process:
 
   ```python
+  import os
+  import subprocess
+
   env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
   subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
   ```

--- a/reference/7.7/Microsoft.PowerShell.Core/About/about_PSModulePath.md
+++ b/reference/7.7/Microsoft.PowerShell.Core/About/about_PSModulePath.md
@@ -1,7 +1,7 @@
 ---
 description: The PSModulePath environment variable contains a list of folder locations that are searched to find modules and resources.
 Locale: en-US
-ms.date: 10/14/2024
+ms.date: 08/25/2026
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_PSModulePath?view=powershell-7.7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_PSModulePath
@@ -120,6 +120,45 @@ following modifications:
 The PS7 paths are removed so that PS7 modules don't get loaded in Windows
 PowerShell. The `WinPSModulePath` value is used when starting Windows
 PowerShell.
+
+This modification only applies to Windows PowerShell processes that
+PowerShell 7 starts directly. When Windows PowerShell is started through an
+intermediate process, such as a `cmd.exe` or Python process that PowerShell 7
+launched, the intermediate process inherits the unmodified
+`$Env:PSModulePath` of PowerShell 7 and passes it on to its own child
+processes. Windows PowerShell started this way keeps the inherited
+PowerShell 7 module paths. Because those paths precede the Windows PowerShell
+system module path, Windows PowerShell can resolve shared module names, such
+as `Microsoft.PowerShell.Utility`, to PowerShell 7 module versions that it
+can't load. This breaks module autoloading, and the cmdlets from those
+modules fail with a `CommandNotFoundException` error.
+
+To start Windows PowerShell from an intermediate process with the correct
+module paths, remove `PSModulePath` from the environment of the child
+process. Windows PowerShell then constructs its default value at startup. For
+example:
+
+- In PowerShell 7.4 and higher, use the **Environment** parameter of
+  `Start-Process` to remove the variable from the environment of the
+  intermediate process:
+
+  ```powershell
+  Start-Process python harness.py -Environment @{ PSModulePath = $null }
+  ```
+
+- In `cmd.exe`, clear the variable before starting Windows PowerShell:
+
+  ```cmd
+  cmd /c "set PSModulePath=&& powershell.exe -File script.ps1"
+  ```
+
+- In Python, remove the variable from the environment that you pass to the
+  child process:
+
+  ```python
+  env = {k: v for k, v in os.environ.items() if k.upper() != "PSMODULEPATH"}
+  subprocess.run(["powershell.exe", "-File", "script.ps1"], env=env)
+  ```
 
 ### Starting PowerShell 7 from Windows PowerShell
 


### PR DESCRIPTION
# PR Summary

The "Starting Windows PowerShell from PowerShell 7" section of
`about_PSModulePath` documents that PowerShell 7 sanitizes `PSModulePath`
when it starts Windows PowerShell, but not that this only covers processes
PowerShell 7 starts **directly**. When Windows PowerShell is started through
an intermediate process (`pwsh` -> `cmd.exe`, Python, or any other native
process -> `powershell.exe`), the intermediate inherits the unmodified
`PSModulePath` of PowerShell 7 and passes it down. The PowerShell 7 module
paths then precede the Windows PowerShell system module path, shared module
names such as `Microsoft.PowerShell.Utility` resolve to PowerShell 7 versions
that Windows PowerShell can't load, and the cmdlets from those modules fail
with `CommandNotFoundException`.

The PowerShell Engine WG reviewed this behavior in
PowerShell/PowerShell#27774, concluded it is by design on both sides, and
invited this documentation enhancement to `about_PSModulePath`.

Changes:

- `reference/7.4|7.5|7.6|7.7/.../About/about_PSModulePath.md`: document the
  direct-children limitation at the end of "Starting Windows PowerShell from
  PowerShell 7", with three verified workarounds (PowerShell 7.4+
  `Start-Process -Environment`, `cmd.exe` `set PSModulePath=`, Python
  `subprocess` with the variable removed).
- `reference/5.1/.../About/about_PSModulePath.md`: add a note on the
  inheriting side under "Windows PowerShell startup", cross-linking the
  PowerShell 7 article.
- Update `ms.date` in the five touched files.

Every behavior described was measured on Windows 11 (pwsh 7.6.4, Windows
PowerShell 5.1.26100.8972): direct child sanitized (6 entries -> 4), one
intermediate process of any kind sufficient to reproduce (6 entries kept,
`CommandNotFoundException`), each workaround verified. Details in
PowerShell/PowerShell#27774.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
