### PR TITLE
Add missing link in creating-a-cmdlet-to-access-a-data-store.md

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-to-access-a-data-store.md
+++ b/reference/docs-conceptual/developer/cmdlet/creating-a-cmdlet-to-access-a-data-store.md
@@ -1308,6 +1308,7 @@ command line. The following procedure can be used to test the sample Select-Str 
 [01]: /previous-versions/powershell/scripting/developer/prog-guide/designing-your-windows-powershell-provider
 [02]: ../windows-powershell-reference.md
 [03]: ./adding-parameter-sets-to-a-cmdlet.md
+[04]: ./adding-parameters-that-process-command-line-input.md
 [05]: ./approved-verbs-for-windows-powershell-commands.md
 [06]: ./creating-a-cmdlet-that-modifies-the-system.md
 [07]: ./creating-a-cmdlet-without-parameters.md


### PR DESCRIPTION
Just a missing link to `./adding-parameters-that-process-command-line-input.md` in the document which I've added.

# PR Summary

This change fixes a missing link in the documentation for "Creating a Cmdlet to Access a Data Store".

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributor's guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].