### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
   directory: "/"
   schedule:
       interval: "weekly"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: checkout_repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Verify Checklist
         id: verify_checklist
         uses: ./.github/actions/verification/checklist/v1

--- a/.github/workflows/expectations.yml
+++ b/.github/workflows/expectations.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: checkout_repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Comment on Community PRs
         uses: ./.github/actions/commenting/expectations/v1
         with:

--- a/.github/workflows/quality.issue.yml
+++ b/.github/workflows/quality.issue.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       check: ${{ steps.is-quality.outputs.match != '' }}
     steps:
-      - uses: actions-ecosystem/action-regex-match@v2
+      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
         id: is-quality
         with:
           text: ${{ github.event.issue.body }}
@@ -25,7 +25,7 @@ jobs:
     if: needs.quality.outputs.check == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-assignees@v1
+      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747 # v1.0.0
         with:
           github_token: ${{ secrets.github_token }}
           assignees: ${{ github.event.issue.user.login }}
@@ -52,13 +52,13 @@ jobs:
           - regex: Spelling
             label: quality-spelling
     steps:
-      - uses: actions-ecosystem/action-regex-match@v2
+      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
         id: matcher
         with:
           text: ${{ github.event.issue.body }}
           regex: '^### Quality Areas\s*^.*${{ matrix.regex }}.*$'
           flags: gm
-      - uses: actions-ecosystem/action-add-labels@v1
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         if: steps.matcher.outputs.match != ''
         with:
           labels: ${{ matrix.label }}

--- a/.github/workflows/quality.pr.yml
+++ b/.github/workflows/quality.pr.yml
@@ -33,6 +33,6 @@ jobs:
       needs.check.outputs.title == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: project-quality

--- a/.github/workflows/stale-content.yml
+++ b/.github/workflows/stale-content.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: checkout_repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Write Report
         uses: ./.github/actions/reporting/stale-content/v1
         with:

--- a/.github/workflows/targeting-repo-files.yml
+++ b/.github/workflows/targeting-repo-files.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: checkout_repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Authorized to Modify Repo Files?
         uses: ./.github/actions/verification/authorization/v1
         with:

--- a/.github/workflows/targeting-valid-branch.yml
+++ b/.github/workflows/targeting-valid-branch.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: checkout_repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Authorized to Target Live Branch?
         uses: ./.github/actions/verification/authorization/v1
         with:

--- a/.github/workflows/versioned-content.yml
+++ b/.github/workflows/versioned-content.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: checkout_repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Write Report
         uses: ./.github/actions/reporting/versioned-content/v1
         with:


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
