### PR TITLE
docs: fix 'allows to' grammar in Get-Member sample

### DIFF
--- a/reference/docs-conceptual/samples/Viewing-Object-Structure--Get-Member-.md
+++ b/reference/docs-conceptual/samples/Viewing-Object-Structure--Get-Member-.md
@@ -1,5 +1,5 @@
 ---
-description: Get-Member is a powerful tool that allows to see the type and structure of objects in PowerShell.
+description: Get-Member is a powerful tool that allows you to see the type and structure of objects in PowerShell.
 ms.date: 12/08/2022
 title: Viewing object structure
 ---


### PR DESCRIPTION
Tiny docs grammar fix.